### PR TITLE
Remove tsc from build scripts in JS vite demos

### DIFF
--- a/absolute-port-layout-dynamic-port-sizes/js/package.json
+++ b/absolute-port-layout-dynamic-port-sizes/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/activity-diagram/js/package.json
+++ b/activity-diagram/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/alignment-and-distance-based-position-guides/js/package.json
+++ b/alignment-and-distance-based-position-guides/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/animated-process-flow-diagram/js/package.json
+++ b/animated-process-flow-diagram/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/automatic-link-teleports/js/package.json
+++ b/automatic-link-teleports/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/callouts/js/package.json
+++ b/callouts/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/change-element-text-alignment-in-inspector/js/package.json
+++ b/change-element-text-alignment-in-inspector/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/chatgpt-timeline/js/package.json
+++ b/chatgpt-timeline/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/circular-layout/js/package.json
+++ b/circular-layout/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/clipboard-api-integration/js/package.json
+++ b/clipboard-api-integration/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/collapsible-minimap/js/package.json
+++ b/collapsible-minimap/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/comment-view/js/package.json
+++ b/comment-view/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/confirmation-dialogs/js/package.json
+++ b/confirmation-dialogs/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/connecting-nodes-by-dragging-and-dropping/js/package.json
+++ b/connecting-nodes-by-dragging-and-dropping/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/connector-arrows/js/package.json
+++ b/connector-arrows/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/content-driven-shapes/js/package.json
+++ b/content-driven-shapes/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/context-toolbar/js/package.json
+++ b/context-toolbar/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/control-tool/js/package.json
+++ b/control-tool/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/copy-paste/js/package.json
+++ b/copy-paste/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/corporate-organizational-chart/js/package.json
+++ b/corporate-organizational-chart/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/counters/js/package.json
+++ b/counters/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/curve-connector/js/package.json
+++ b/curve-connector/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/decision-tree-analysis/js/package.json
+++ b/decision-tree-analysis/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/decision-tree/js/package.json
+++ b/decision-tree/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/diagram-generation-from-external-data/js/package.json
+++ b/diagram-generation-from-external-data/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/different-views-of-the-same-graph/js/package.json
+++ b/different-views-of-the-same-graph/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/drop-image-as-shape/js/package.json
+++ b/drop-image-as-shape/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/drop-stencil-element-as-shape-icon/js/package.json
+++ b/drop-stencil-element-as-shape-icon/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/dynamic-font-size/js/package.json
+++ b/dynamic-font-size/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/dynamic-status-icons/js/package.json
+++ b/dynamic-status-icons/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/dynamic-tooltip-content/js/package.json
+++ b/dynamic-tooltip-content/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/electric-generator/js/package.json
+++ b/electric-generator/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/element-connect-tool/js/package.json
+++ b/element-connect-tool/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/element-grouping/js/package.json
+++ b/element-grouping/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/element-neighborhood-dialog-window/js/package.json
+++ b/element-neighborhood-dialog-window/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/element-palette-tooltips/js/package.json
+++ b/element-palette-tooltips/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/element-port-and-link-label-markup/js/package.json
+++ b/element-port-and-link-label-markup/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/element-tags-and-badges/js/package.json
+++ b/element-tags-and-badges/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/external-svg-images/js/package.json
+++ b/external-svg-images/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/fault-tree-analysis/js/package.json
+++ b/fault-tree-analysis/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/fills/js/package.json
+++ b/fills/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/find-all-cells-between-2-elements/js/package.json
+++ b/find-all-cells-between-2-elements/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/finite-object-pool/js/package.json
+++ b/finite-object-pool/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/fixed-connection-points/js/package.json
+++ b/fixed-connection-points/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/flowchart/js/package.json
+++ b/flowchart/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/font-awesome/js/package.json
+++ b/font-awesome/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/hexagonal-grid/js/package.json
+++ b/hexagonal-grid/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/hierarchical-diagrams/js/package.json
+++ b/hierarchical-diagrams/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/highlighter-view-update-attribute/js/package.json
+++ b/highlighter-view-update-attribute/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/hover-element-connect-tool/js/package.json
+++ b/hover-element-connect-tool/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/hover-link-connect-tool/js/package.json
+++ b/hover-link-connect-tool/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/infinite-paper-vs-sheets/js/package.json
+++ b/infinite-paper-vs-sheets/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/inspector-dynamic-element-type/js/package.json
+++ b/inspector-dynamic-element-type/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/inspector-for-selection/js/package.json
+++ b/inspector-for-selection/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/json-visualizer/js/package.json
+++ b/json-visualizer/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/link-connect-tool/js/package.json
+++ b/link-connect-tool/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/list-of-links-in-inspector/js/package.json
+++ b/list-of-links-in-inspector/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/microsoft-adaptive-cards/js/package.json
+++ b/microsoft-adaptive-cards/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/move-elements-via-keyboard/js/package.json
+++ b/move-elements-via-keyboard/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/nodejs-milestones-timeline/js/package.json
+++ b/nodejs-milestones-timeline/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/optional-ports/js/package.json
+++ b/optional-ports/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/parametric-diagram/js/package.json
+++ b/parametric-diagram/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/pdf-export/js/package.json
+++ b/pdf-export/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/port-drag-drop/js/package.json
+++ b/port-drag-drop/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/port-inspector/js/package.json
+++ b/port-inspector/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/port-reordering-tool/js/package.json
+++ b/port-reordering-tool/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/presentation-mode/js/package.json
+++ b/presentation-mode/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/preserve-spaces-in-text-wrap/js/package.json
+++ b/preserve-spaces-in-text-wrap/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/rectangular-layout/js/package.json
+++ b/rectangular-layout/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/resize-control-tool/js/package.json
+++ b/resize-control-tool/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/roi-calculator/js/package.json
+++ b/roi-calculator/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/sankey-diagram/js/package.json
+++ b/sankey-diagram/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/scada/js/package.json
+++ b/scada/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/scale-option-for-tools/js/package.json
+++ b/scale-option-for-tools/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/scale-svgmarker/js/package.json
+++ b/scale-svgmarker/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/searchable-sitemap/js/package.json
+++ b/searchable-sitemap/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/selection-alignment/js/package.json
+++ b/selection-alignment/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/serpentine-layout/js/package.json
+++ b/serpentine-layout/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/shape-builder/js/package.json
+++ b/shape-builder/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/shapes-drawing/js/package.json
+++ b/shapes-drawing/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/snap-links-to-themselves/js/package.json
+++ b/snap-links-to-themselves/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/spreadsheet-shapes-with-handsontable/js/package.json
+++ b/spreadsheet-shapes-with-handsontable/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/stencil-favorite-in-use-groups/js/package.json
+++ b/stencil-favorite-in-use-groups/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/stencil-theme-picker/js/package.json
+++ b/stencil-theme-picker/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/stencil-vs-diagram-elements/js/package.json
+++ b/stencil-vs-diagram-elements/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/text-position-based-on-space-availability/js/package.json
+++ b/text-position-based-on-space-availability/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/the-archimate-enterprise-architecture-modeling-language/js/package.json
+++ b/the-archimate-enterprise-architecture-modeling-language/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/touch-gestures/js/package.json
+++ b/touch-gestures/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/tournament-brackets/js/package.json
+++ b/tournament-brackets/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/translate-connected-links-in-selection/js/package.json
+++ b/translate-connected-links-in-selection/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/tree-graph-and-cycles/js/package.json
+++ b/tree-graph-and-cycles/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/tree-graph-with-add-buttons/js/package.json
+++ b/tree-graph-with-add-buttons/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/ui-popup/js/package.json
+++ b/ui-popup/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/uml-class-diagrams/js/package.json
+++ b/uml-class-diagrams/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/uml-class-shape-inspector/js/package.json
+++ b/uml-class-shape-inspector/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/upload-image-to-stencil/js/package.json
+++ b/upload-image-to-stencil/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/use-case-diagram/js/package.json
+++ b/use-case-diagram/js/package.json
@@ -6,7 +6,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "tsc && vite build",
+        "build": "vite build",
         "preview": "vite preview"
     },
     "devDependencies": {

--- a/view-edit-mode/js/package.json
+++ b/view-edit-mode/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/working-with-ports/js/package.json
+++ b/working-with-ports/js/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Removed `tsc && ` from the `build` script in 99 JavaScript (vite-based) demo `package.json` files
- JS demos don't need TypeScript compilation, so the build script now runs `vite build` directly instead of `tsc && vite build`

## Test plan
- [x] Verify a sample JS demo builds successfully with `npm run build`
- [x] Confirm no JS demo still references `tsc` in its build script

🤖 Generated with [Claude Code](https://claude.com/claude-code)