### PR TITLE
Fix SVG imports used in selection.addHandle()

### DIFF
--- a/confirmation-dialogs/js/src/main.js
+++ b/confirmation-dialogs/js/src/main.js
@@ -2,7 +2,7 @@ import { dia, ui, shapes, linkTools, elementTools, V } from '@joint/plus';
 import './styles.scss';
 
 // Asset imports
-import trashSvg from '../assets/icons/trash.svg';
+import trashSvg from '../assets/icons/trash.svg?no-inline';
 
 const graph = new dia.Graph({}, { cellNamespace: shapes });
 const paper = new dia.Paper({

--- a/dynamic-stencil/js/src/main.js
+++ b/dynamic-stencil/js/src/main.js
@@ -1,6 +1,6 @@
 import { dia, elementTools, format, layout, shapes, ui } from '@joint/plus';
 import './styles.css';
-import addToStencilIcon from '../assets/add-to-stencil.svg';
+import addToStencilIcon from '../assets/add-to-stencil.svg?no-inline';
 
 const PREVIEW_PADDING = 10;
 

--- a/element-grouping/js/src/main.js
+++ b/element-grouping/js/src/main.js
@@ -2,8 +2,8 @@ import { dia, ui, shapes } from '@joint/plus';
 import './styles.css';
 
 // Asset imports
-import groupSvg from '../assets/icons/group.svg';
-import ungroupSvg from '../assets/icons/ungroup.svg';
+import groupSvg from '../assets/icons/group.svg?no-inline';
+import ungroupSvg from '../assets/icons/ungroup.svg?no-inline';
 
 const graph = new dia.Graph({}, { cellNamespace: shapes });
 const paper = new dia.Paper({

--- a/selection-alignment/js/src/main.js
+++ b/selection-alignment/js/src/main.js
@@ -2,7 +2,7 @@ import { dia, ui, shapes, V } from '@joint/plus';
 import './styles.scss';
 
 // Asset imports
-import alignmentSvg from '../assets/icons/alignment.svg';
+import alignmentSvg from '../assets/icons/alignment.svg?no-inline';
 
 const graph = new dia.Graph({}, { cellNamespace: shapes });
 const paper = new dia.Paper({


### PR DESCRIPTION
## Summary
- Add `?no-inline` query parameter to SVG imports that are used as icons in `selection.addHandle()`
- Affected demos: `confirmation-dialogs`, `dynamic-stencil`, `element-grouping`, `selection-alignment`

## Problem
The `selection.addHandle()` method doesn't work with SVG data URLs. When Vite inlines small SVG files as data URIs (the default behavior), the resulting data URL cannot be used as a handle icon. Adding `?no-inline` forces Vite to emit the SVG as a separate file and return a standard URL instead, which works correctly with `addHandle()`.

## Test plan
- [ ] Verify handle icons render correctly in all 4 affected demos
- [ ] Confirm SVGs are no longer inlined as data URIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)