### PR TITLE
fix: use cross-env for BUILD_PATH in diagram-index and tabs react builds

### DIFF
--- a/demos.config.json
+++ b/demos.config.json
@@ -15,12 +15,10 @@
       "buildFlags": "--configuration production"
     },
     "tabs": {
-      "variant": "angular",
-      "buildFlags": "--configuration production"
+      "variant": "react"
     },
     "diagram-index": {
-      "variant": "angular",
-      "buildFlags": "--configuration production"
+      "variant": "react"
     }
   }
 }

--- a/diagram-index/react/package.json
+++ b/diagram-index/react/package.json
@@ -17,6 +17,7 @@
     "@types/node": "^16.0.0",
     "@types/react": "^17.0.40",
     "@types/react-dom": "^17.0.11",
+    "cross-env": "^7.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "5.0.0",
@@ -26,7 +27,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "cross-env BUILD_PATH=dist react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/tabs/react/package.json
+++ b/tabs/react/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "cross-env": "^7.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.1",
@@ -22,7 +23,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "cross-env BUILD_PATH=dist react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## Summary
- Add `cross-env` dependency to `diagram-index/react` and `tabs/react` packages
- Update build scripts to use `cross-env BUILD_PATH=dist` so output goes to `dist/` instead of `build/` on all platforms (including Windows)
- Switch `tabs` and `diagram-index` demos config to use the `react` variant

## Test plan
- [ ] Run `npm run build` in `diagram-index/react` and verify output is in `dist/`
- [ ] Run `npm run build` in `tabs/react` and verify output is in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)