### PR TITLE
fix: workflow-builder styling tweaks

### DIFF
--- a/workflow-builder/js/assets/icons/inspector-empty.svg
+++ b/workflow-builder/js/assets/icons/inspector-empty.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
-    stroke="#9CA7A9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+    stroke="#97A0AA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
     class="lucide lucide-mouse-pointer-click-icon lucide-mouse-pointer-click">
     <path d="M14 4.1 12 6" />
     <path d="m5.1 8-2.9-.8" />

--- a/workflow-builder/js/src/diagram/theme.js
+++ b/workflow-builder/js/src/diagram/theme.js
@@ -2,94 +2,94 @@
  * Theme constants for the Generic Workflow Builder diagram.
  */
 const Theme = {
-    
+
     /* * Background color for control nodes */
     ControlBackgroundColor: '#F1FBED',
-    
+
     /** Border color for control nodes */
     ControlBorderColor: '#9AD5A3',
-    
+
     /** Border width for control nodes in the diagram. */
     ControlBorderWidth: 1,
-    
+
     /** Outline color for control nodes */
     ControlOutlineColor: '#D7E8D0',
-    
+
     /** Border color of edges in the diagram. */
-    EdgeColor: '#B8CACD',
-    
+    EdgeColor: '#A5ADB6',
+
     /** Color used to highlight edges during preview (e.g., when dragging a new connection) */
     EdgePreviewColor: '#275EE7',
-    
+
     /** Width of edges in the diagram. */
     EdgeWidth: 2,
-    
+
     /** Font family used throughout the diagram */
     FontFamily: 'Inter, sans-serif',
-    
+
     /** Icon size for images in shapes. */
     IconSize: 38,
-    
+
     /** Input port background color */
     InPortBackgroundColor: '#FFFFFF',
-    
+
     /** Input port border color */
     InPortBorderColor: '#275EE7',
-    
+
     /** Input port border width */
     InPortBorderWidth: 3,
-    
+
     /** Background color for nodes */
     NodeBackgroundColor: '#FFFFFF',
-    
+
     /** Border color for nodes */
     NodeBorderColor: '#BECDF4',
-    
+
     /** Border width for nodes in the diagram. */
     NodeBorderWidth: 1,
-    
+
     /** Text color for nodes */
     NodeLabelColor: '#333333',
-    
+
     /** Outline color for nodes */
     NodeOutlineColor: '#CFDCEF',
-    
+
     /** Size of the menu tool */
     NodeToolSize: 24,
-    
+
     /** Margin around the icon inside the menu tool. */
     NodeToolPadding: 0,
-    
+
     /** Text color for node type labels */
     NodeTypeLabelColor: '#6E7A91',
-    
+
     /** Background color for notes */
     NoteBackgroundColor: '#F6EEB8',
-    
+
     /** Border color for notes */
     NoteBorderColor: '#BECDF4',
-    
+
     /** Border radius for notes */
     NoteBorderRadius: 14,
-    
+
     /** Note content padding */
     NotePadding: 16,
-    
+
     /** Text color for notes */
     NoteTextColor: '#333333',
-    
+
     /** Output port background color */
     OutPortBackgroundColor: '#D8E3F2',
-    
+
     /** Output port border color */
     OutPortBorderColor: '#BECDF4',
-    
+
     /** Output port border width */
     OutPortBorderWidth: 1,
-    
+
     /** Output port icon color */
     OutPortIconColor: '#8BA2DB',
-    
+
     /** Color for trigger marker */
     TriggerMarkerColor: '#454B6E',
 };

--- a/workflow-builder/js/styles/inspector.scss
+++ b/workflow-builder/js/styles/inspector.scss
@@ -216,6 +216,7 @@
             border-radius: 6px;
             background-color: var(--app-bg-tertiary);
             padding: 5px;
+            object-fit: contain;
         }
 
         .inspector-header-text-wrapper {

--- a/workflow-builder/ts/assets/icons/inspector-empty.svg
+++ b/workflow-builder/ts/assets/icons/inspector-empty.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
-    stroke="#9CA7A9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+    stroke="#97A0AA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
     class="lucide lucide-mouse-pointer-click-icon lucide-mouse-pointer-click">
     <path d="M14 4.1 12 6" />
     <path d="m5.1 8-2.9-.8" />

--- a/workflow-builder/ts/src/diagram/theme.ts
+++ b/workflow-builder/ts/src/diagram/theme.ts
@@ -16,7 +16,7 @@ const Theme = {
     ControlOutlineColor: '#D7E8D0',
 
     /** Border color of edges in the diagram. */
-    EdgeColor: '#B8CACD',
+    EdgeColor: '#A5ADB6',
 
     /** Color used to highlight edges during preview (e.g., when dragging a new connection) */
     EdgePreviewColor: '#275EE7',

--- a/workflow-builder/ts/styles/inspector.scss
+++ b/workflow-builder/ts/styles/inspector.scss
@@ -216,6 +216,7 @@
             border-radius: 6px;
             background-color: var(--app-bg-tertiary);
             padding: 5px;
+            object-fit: contain;
         }
 
         .inspector-header-text-wrapper {


### PR DESCRIPTION
## Summary

- Update `EdgeColor` from `#B8CACD` to `#A5ADB6` for better contrast in both JS and TS variants
- Update `inspector-empty.svg` icon stroke colour from `#9CA7A9` to `#97A0AA` to align with the new edge colour
- Add `object-fit: contain` to the inspector header icon to prevent image distortion

## Test plan

- [x] Open the workflow-builder JS demo and verify edge colour and inspector icon look correct
- [x] Open the workflow-builder TS demo and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)