### PR TITLE
Move flowchart demo from JointJS+ to @joint/core

### DIFF
--- a/flowchart/README.md
+++ b/flowchart/README.md
@@ -1,4 +1,4 @@
-# JointJS+: Flowchart <a href="https://www.jointjs.com/jointjs-plus"><img src="../jointjs-plus-badge.svg" alt="JointJS+" width="123" align="right" /></a>
+# JointJS+: Flowchart
 
 This flowchart created using our JavaScript/Typescript flowchart library shows a simple checkout process. Use it as a boilerplate for your application and let your users design the sequence of movements or actions. This demo application can be easily integrated into TypeScript, React, Angular, Vue, Svelte, and LightningJS. In addition, you can learn how to style the diagram in CSS and switch between light and dark modes.
 

--- a/flowchart/README.md
+++ b/flowchart/README.md
@@ -1,4 +1,4 @@
-# JointJS+: Flowchart
+# JointJS: Flowchart
 
 This flowchart created using our JavaScript/Typescript flowchart library shows a simple checkout process. Use it as a boilerplate for your application and let your users design the sequence of movements or actions. This demo application can be easily integrated into TypeScript, React, Angular, Vue, Svelte, and LightningJS. In addition, you can learn how to style the diagram in CSS and switch between light and dark modes.
 

--- a/flowchart/js/.npmrc
+++ b/flowchart/js/.npmrc
@@ -1,3 +1,0 @@
-@joint:registry=https://npm.jointjs.com
-always-auth=true
-//npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/flowchart/js/README.md
+++ b/flowchart/js/README.md
@@ -1,4 +1,4 @@
-# JointJS+: Flowchart (JavaScript) <a href="https://www.jointjs.com/jointjs-plus"><img src="../../jointjs-plus-badge.svg" alt="JointJS+" width="123" align="right" /></a>
+# JointJS+: Flowchart (JavaScript)
 
 This flowchart created using our JavaScript/Typescript flowchart library shows a simple checkout process. Use it as a boilerplate for your application and let your users design the sequence of movements or actions. This demo application can be easily integrated into TypeScript, React, Angular, Vue, Svelte, and LightningJS. In addition, you can learn how to style the diagram in CSS and switch between light and dark modes.
 
@@ -16,26 +16,7 @@ Alternatively, you can get the [copy of the repository](https://github.com/clien
 
 ## Running the application
 
-To run this application you need to have access to JointJS+ package. You can get it by having a JointJS+ license or by starting a [free trial](https://www.jointjs.com/free-trial).
-
-If you are a trial user, you received your access token during the trial sign-up process.
-If you are a customer, log in to the customer portal at https://my.jointjs.com to obtain your access token.
-
-This example uses `.npmrc` file to set up access to the JointJS+ private npm registry. By default it uses `JOINTJS_NPM_TOKEN` environment variable to get authentication token. You can set this environment variable in your terminal or CI environment in the following way:
-
-**macOS / Linux**:
-```sh
-export JOINTJS_NPM_TOKEN="jjs-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-```
-
-**Windows (PowerShell)**:
-```sh
-$env:JOINTJS_NPM_TOKEN="jjs-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-```
-
-Learn more about our [private npm registry here.](https://docs.jointjs.com/learn/help-center/npm-registry)
-
-After setting up access to JointJS+ package, install the dependencies by running:
+Install the dependencies by running:
 
 ```bash
 npm install

--- a/flowchart/js/README.md
+++ b/flowchart/js/README.md
@@ -1,4 +1,4 @@
-# JointJS+: Flowchart (JavaScript)
+# JointJS: Flowchart (JavaScript)
 
 This flowchart created using our JavaScript/Typescript flowchart library shows a simple checkout process. Use it as a boilerplate for your application and let your users design the sequence of movements or actions. This demo application can be easily integrated into TypeScript, React, Angular, Vue, Svelte, and LightningJS. In addition, you can learn how to style the diagram in CSS and switch between light and dark modes.
 

--- a/flowchart/js/package.json
+++ b/flowchart/js/package.json
@@ -14,6 +14,6 @@
     "vite": "^7.3.1"
   },
   "dependencies": {
-    "@joint/plus": "4.2.3"
+    "@joint/core": "^4.2.4"
   }
 }

--- a/flowchart/js/src/main.js
+++ b/flowchart/js/src/main.js
@@ -1,4 +1,4 @@
-import { dia, shapes, highlighters, linkTools } from '@joint/plus';
+import { dia, shapes, highlighters, linkTools } from '@joint/core';
 import './styles.scss';
 
 // Styles

--- a/flowchart/js/src/styles.scss
+++ b/flowchart/js/src/styles.scss
@@ -1,5 +1,3 @@
-@import '@joint/plus/joint-plus.css';
-
 :root {
     /* JointJS Palette */
     --jj-color1: #ed2637;


### PR DESCRIPTION
## Summary
- Migrates the flowchart JS demo from `@joint/plus` (private registry) to `@joint/core` (public npm)
- Removes `.npmrc` and private registry configuration, eliminating the need for an access token
- Simplifies setup instructions in README files accordingly
- Removes JointJS+ badge links from README headings

## Test plan
- [ ] Run `npm install` in `flowchart/js/` and verify it resolves `@joint/core` from public npm without auth
- [ ] Run `npm run dev` and verify the flowchart demo renders correctly
- [ ] Confirm no references to `@joint/plus` remain in `flowchart/js/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)