### PR TITLE
fix(uml-class-shape-inspector): fix inspector and add proper cell namespaces

### DIFF
--- a/uml-class-shape-inspector/js/index.html
+++ b/uml-class-shape-inspector/js/index.html
@@ -12,7 +12,7 @@
 <body id="app">
     <div id="demo">
         <div id="paper"></div>
-        <div id="inspector" style="position:relative;width:50%;height:100%;">
+        <div id="inspector">
             <div class="inspector-buttons">
                 <button class="inspector-tab-button" data-inspector="inspector-general">General</button>
                 <button class="inspector-tab-button" data-inspector="inspector-attributes">Attributes</button>

--- a/uml-class-shape-inspector/js/src/main.js
+++ b/uml-class-shape-inspector/js/src/main.js
@@ -231,14 +231,17 @@ class UMLClass extends shapes.standard.HeaderedRecord {
     }
 }
 
-shapes.UMLClass = UMLClass;
-shapes.UMLClassView = shapes.standard.HeaderedRecordView;
+const namespace = {
+    ...shapes,
+    UMLClass,
+    UMLClassView: shapes.standard.HeaderedRecordView
+};
 
-const graph = new dia.Graph({}, { cellNamespace: shapes });
+const graph = new dia.Graph({}, { cellNamespace: namespace });
 const paper = new dia.Paper({
     el: document.getElementById('paper'),
     model: graph,
-    cellViewNamespace: shapes,
+    cellViewNamespace: namespace,
     width: '50%',
     height: '100%',
     background: {
@@ -360,16 +363,20 @@ const inspectorAttributes = new ui.Inspector({
                         index: 1
                     },
                     visibility: {
-                        type: 'select',
+                        type: 'select-box',
                         options: visibilityOptions,
                         label: 'Visibility',
-                        index: 2
+                        index: 2,
+                        target: '#inspector',
+                        width: '100%'
                     },
                     returnType: {
-                        type: 'select',
+                        type: 'select-box',
                         options: 'typeOptions',
                         label: 'Return type',
-                        index: 3
+                        index: 3,
+                        target: '#inspector',
+                        width: '100%'
                     },
                     isStatic: {
                         type: 'toggle',
@@ -402,16 +409,20 @@ const inspectorOperations = new ui.Inspector({
                         index: 1
                     },
                     visibility: {
-                        type: 'select',
+                        type: 'select-box',
                         options: visibilityOptions,
                         label: 'Visibility',
-                        index: 2
+                        index: 2,
+                        target: '#inspector',
+                        width: '100%'
                     },
                     returnType: {
-                        type: 'select',
+                        type: 'select-box',
                         options: 'typeOptions',
                         label: 'Return type',
-                        index: 3
+                        index: 3,
+                        target: '#inspector',
+                        width: '100%'
                     },
                     isStatic: {
                         type: 'toggle',
@@ -429,10 +440,12 @@ const inspectorOperations = new ui.Inspector({
                                     label: 'Parameter name'
                                 },
                                 type: {
-                                    type: 'select',
+                                    type: 'select-box',
                                     options: 'typeOptions',
                                     index: 2,
-                                    label: 'Parameter type'
+                                    label: 'Parameter type',
+                                    target: '#inspector',
+                                    width: '100%'
                                 }
                             }
                         },

--- a/uml-class-shape-inspector/js/src/styles.css
+++ b/uml-class-shape-inspector/js/src/styles.css
@@ -58,3 +58,7 @@ body {
     width: 100px;
     background: white;
 }
+
+.joint-select-box-options {
+    width: calc(100% - 55px) !important;
+}


### PR DESCRIPTION
## Summary
- Switch inspector `select` fields (visibility, return type, parameter type) to `select-box` so options render in an overlay instead of a native dropdown, fixing usability in the inspector panel
- Register a custom cell namespace instead of mutating the shared `shapes` object, avoiding pollution of the global namespace with `UMLClass`

## Test plan
- [ ] Run the `uml-class-shape-inspector/js` demo and confirm the inspector panel renders correctly
- [ ] Verify visibility/return-type/parameter-type dropdowns open as select-box overlays and display correctly within the panel width