### PR TITLE
fix: measure mermaid-editor nodes in the production build

### DIFF
--- a/mermaid-editor/react/src/components/render-node.tsx
+++ b/mermaid-editor/react/src/components/render-node.tsx
@@ -35,7 +35,26 @@ export function RenderNode(data: NodeData) {
     const isEditing = editing !== null && cellId !== undefined && editing.editingId === cellId;
     const label = data.label;
     const spec = getShapeSpec(data.shape);
-    const textRef = useRef<SVGTextElement>(null);
+    /*
+     * The measured node is held in state, not in a plain ref.
+     *
+     * `SVGText` forwards its ref through `useCombinedRef`, which assigns it in
+     * a passive effect rather than synchronously on commit. `useMeasureElement`
+     * reads the ref in a *layout* effect — one phase earlier — so on the first
+     * commit it sees `null`, returns early, and never registers the node with
+     * the size observer: its dependencies do not include the node, so nothing
+     * makes it run again. The element then stays 0×0 for good, which renders as
+     * a bare label with no shape behind it and no layout.
+     *
+     * Development hid this. React's StrictMode remounts effects there, and the
+     * second pass finds the ref already set by the first pass's passive effect,
+     * so it only ever broke in a production build.
+     *
+     * Keeping the node in state produces a fresh ref object the moment the text
+     * is attached, which re-runs the hook's effect with a node to register.
+     */
+    const [textNode, setTextNode] = useState<SVGTextElement | null>(null);
+    const textRef = useMemo(() => ({ current: textNode }), [textNode]);
     const options = useMemo(() => ({ transform: spec.size }), [spec]);
     const { width, height } = useMeasureElement(textRef, options);
 
@@ -49,7 +68,7 @@ export function RenderNode(data: NodeData) {
         <>
             <SVGShape shape={data.shape} width={width} height={height} style={data.style?.body} />
             <SVGText
-                ref={textRef}
+                ref={setTextNode}
                 style={data.style?.text}
                 // Kept mounted while editing: this is what `useMeasureElement`
                 // measures, so hiding it rather than unmounting it holds the


### PR DESCRIPTION
Follow-up to #25. Built for production, every node in the mermaid-editor demo rendered as a bare label — no shape behind it and no layout — while `npm run dev` was fine. Elements were stuck at 0×0, so dagre never ran either.

## Cause

`SVGText` forwards its ref through `useCombinedRef`, which assigns the forwarded ref inside a **passive** effect:

```js
function useCombinedRef(ref) {
  const innerRef = useRef(null);
  useEffect(() => { setForwardRef(ref, innerRef.current); }, [ref]);
  return innerRef;
}
```

`useMeasureElement` reads that ref in a **layout** effect — one phase earlier — so on the first commit it sees `null`, returns before `setMeasuredNode`, and never registers the node with the size observer. Its dependency list is `[nodeRef, graph, id, paper, setMeasuredNode]`, none of which change when the node lands, so it never runs again.

Confirmed by wrapping `ResizeObserver` in the page: dev observes all ten `text.mermaid-node-text` nodes, the production build observes none — only the CodeMirror and paper containers.

Development hid it because StrictMode remounts effects there, and the second pass finds the ref already set by the first pass. The two hooks only ever worked together by accident of a dev-only behaviour.

## Fix

Hold the measured node in state, so the hook gets a fresh ref object the moment the text is attached and re-runs its effect with something to register. Contained to the demo; the reasoning is in a comment at the call site.

## Note for the library

This is arguably worth fixing upstream — `useCombinedRef` assigning in a passive effect is incompatible with any consumer that reads the ref in a layout effect, and `useMeasureElement` is exactly that consumer. A callback ref in `useCombinedRef`, or a node-aware dependency in `useMeasureElement`, would remove the trap for everyone. Happy to file a repro against `joint` if useful.

## Verification

Against `vite preview`, not just dev — which is how this slipped through in the first place. Note `compare-screenshots.mjs` and `screenshot-demos.mjs` both run `npm run dev`, so no existing check would have caught it.

- sizes and positions correct (`start` 194×40 at `translate(144,20)`, previously 0×0 at `translate(0,0)`)
- all six examples render with the expected node and edge counts
- inline multiline editing, the shape/fill toolbar and SVG export all work
- no console errors
- `npm run typecheck`, demo lint, root ESLint and `npm run build` clean
- dev screenshot baseline still matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)