### PR TITLE
fix: read a node's label from its shape delimiters, not from NodeText

### DIFF
--- a/mermaid-editor/react/README.md
+++ b/mermaid-editor/react/README.md
@@ -33,6 +33,10 @@ Mermaid renders a static image. Rendering the same source through JointJS+ gives
 
 Only the `flowchart` (and legacy `graph`) diagram type is supported; any other Mermaid diagram is reported as unsupported. `subgraph` blocks are parsed but flattened — their members are rendered as ordinary nodes and a notice says how many groups were dropped. Mermaid's `click` directives are ignored, and edge styling (`linkStyle`) is not applied.
 
+Two parsers read the same text, and that is the demo's structural weak point. Mermaid supplies the graph, but its flowchart grammar is still the jison one inside `mermaid` core, and the normalised `getData()` output carries no source positions — so the editing features get their offsets from a second, independent grammar (`codemirror-lang-mermaid`'s Lezer parser). Anywhere the two disagree, an edit can land in the wrong place: Lezer requires a direction after `flowchart` where Mermaid defaults it to `TB` (worked around in `flowchart-tree.ts` by inserting one for the parse and mapping the offsets back), and it reads `[/label/]` as `[`…`]` around a label containing slashes, so the label span has to be taken from the shape's delimiters rather than from `NodeText`. Expect more of these for the shapes the demo does not model — the trapezoids, `(((double circle)))`, the `@{ shape: ... }` syntax.
+
+The clean fix is upstream. Mermaid's Langium parser (`@mermaid-js/parser`) exposes `$cstNode.offset` / `$cstNode.length` on every AST node, which is exactly what a source-editing tool needs — but as of 1.2.0 it covers only `architecture`, `gitGraph`, `info`, `packet`, `pie`, `radar` and `treemap`. If flowchart moves onto it, the offsets would come from the same parse as the semantics and the second grammar could be dropped entirely.
+
 ## How to download this demo
 
 You can download this demo using our [`@joint/cli` tool](https://www.npmjs.com/package/@joint/cli):

--- a/mermaid-editor/react/src/mermaid/edit-source.ts
+++ b/mermaid-editor/react/src/mermaid/edit-source.ts
@@ -32,6 +32,38 @@ export const SHAPE_SYNTAX = {
 
 export type EditableShape = keyof typeof SHAPE_SYNTAX;
 
+/** Longest opening delimiter first, so `[/` is tried before `[`. */
+const DELIMITER_PAIRS = Object.values(SHAPE_SYNTAX)
+    .toSorted((a, b) => b[0].length - a[0].length);
+
+/**
+ * How many characters of delimiter sit on each side of the label.
+ *
+ * The grammar's `NodeText` is not reliably the label. For `[/Wrapped/]` the
+ * span includes the slashes, because the parser reads the shape as `[`...`]`
+ * with a label that happens to start and end with `/`. Trusting it meant a
+ * reshape carried the slashes into the new delimiters — `{/Wrapped/}`, and
+ * `[//Wrapped//]` the second time round — while a rename replaced them and
+ * quietly turned the parallelogram into a rectangle.
+ *
+ * Reading the delimiters off the shape span instead makes both operate on the
+ * label alone. Shapes this demo cannot switch between (Mermaid's asymmetric
+ * `>text]`, the trapezoids) match nothing here and keep using `NodeText`.
+ * @returns Opening and closing delimiter lengths, or `null` if unrecognised.
+ */
+function delimiterWidths(shapeText: string): readonly [number, number] | null {
+    for (const [open, close] of DELIMITER_PAIRS) {
+        if (
+            shapeText.length >= open.length + close.length
+            && shapeText.startsWith(open)
+            && shapeText.endsWith(close)
+        ) {
+            return [open.length, close.length];
+        }
+    }
+    return null;
+}
+
 /** A node's declaration in the source: `start([Ticket raised])`. */
 interface Declaration {
     readonly id: string;
@@ -96,13 +128,17 @@ function parse(source: string): Parsed {
         }
         const label = nodes[index + 2];
         const hasLabel = label?.name === 'NodeText' && label.from >= next.from && label.to <= next.to;
+        const widths = delimiterWidths(source.slice(next.from, next.to));
+        const span = widths
+            ? { labelFrom: next.from + widths[0], labelTo: next.to - widths[1] }
+            : hasLabel ? { labelFrom: label.from, labelTo: label.to } : {};
         declarations.push({
             id,
             idFrom: node.from,
             idTo: node.to,
             shapeFrom: next.from,
             shapeTo: next.to,
-            ...(hasLabel ? { labelFrom: label.from, labelTo: label.to } : {}),
+            ...span,
         });
     }
 


### PR DESCRIPTION
Reshaping `notify[/Show payment error/]` produced `{/Show payment error/}`, and twice in a row `[//Show payment error//]`. Renaming it produced `notify[Renamed]`, dropping the parallelogram.

The Lezer grammar reads `[/text/]` as `[`...`]` around a label that starts and ends with `/`, so its `NodeText` span includes the slashes. The label span now comes from the shape's own delimiters instead. Shapes the demo can't switch between (`>text]`, the trapezoids) match no known pair and keep using `NodeText`.

Verified: all 9 shapes cycle cleanly from a parallelogram and back, renaming keeps the shape, `g>Asymmetric]` still renames correctly. Typecheck, lint, build and the screenshot comparison clean.