### PR TITLE
fix: re-measure a mermaid-editor node when its shape changes

### DIFF
--- a/mermaid-editor/react/src/components/render-node.tsx
+++ b/mermaid-editor/react/src/components/render-node.tsx
@@ -54,8 +54,25 @@ export function RenderNode(data: NodeData) {
      * is attached, which re-runs the hook's effect with a node to register.
      */
     const [textNode, setTextNode] = useState<SVGTextElement | null>(null);
-    const textRef = useMemo(() => ({ current: textNode }), [textNode]);
-    const options = useMemo(() => ({ transform: spec.size }), [spec]);
+    /*
+     * Keyed on the shape as well as the node, so switching shape re-registers.
+     *
+     * `useMeasureElement` captures the `transform` at registration and its
+     * effect does not depend on it, so a new transform alone is never picked
+     * up. Nothing re-measures either: the label is the observed element and its
+     * box does not change when the shape does. The element therefore kept the
+     * previous shape's size — a circle turned into a rectangle stayed a 59x59
+     * square instead of losing the padding a circle needs for its diagonal.
+     *
+     * A fresh ref object makes the hook's effect re-run, which re-observes the
+     * node and recomputes the size through the new shape's transform. Both come
+     * out of one memo because together they *are* the registration: this node,
+     * measured through this shape's padding.
+     */
+    const { textRef, options } = useMemo(() => ({
+        textRef: { current: textNode },
+        options: { transform: spec.size },
+    }), [textNode, spec]);
     const { width, height } = useMeasureElement(textRef, options);
 
     const cx = width / 2;


### PR DESCRIPTION
Switching a circle to a rectangle left it a 59x59 square instead of dropping to 76x41 — the element kept the previous shape's size.

Each shape has its own size transform, but `useMeasureElement` captures `transform` at registration and its effect doesn't depend on it, so a new one is never picked up. Nothing re-measures either: the observed element is the label, whose box doesn't change when the shape does. Keying the measured ref on the shape as well as the node re-runs the effect, which re-observes and recomputes through the new transform.

Verified across all nine shapes from a circle: rect/rounded 76x41, stadium 88x41, rhombus 108x68, circle 59x59, hexagon 97x41, cylinder 76x63 (= 41 + 2 × `CYLINDER_RY`), subroutine 92x41, parallelogram 97x41. Typecheck, lint, build and the screenshot comparison clean.