### PR TITLE
refactor: move link corner rounding into the routing preset

### DIFF
--- a/mermaid-editor/react/src/components/diagram.tsx
+++ b/mermaid-editor/react/src/components/diagram.tsx
@@ -72,6 +72,15 @@ const INTERACTIONS: InteractionsOptions = { selection: false };
 const SELECTION: SelectionProps = { wrapper: false, allowTranslate: false };
 
 /**
+ * Straight links with a small gap at the end, and rounded corners where dagre's vertices turn the line.
+ */
+const LINK_ROUTING = linkRoutingStraight({
+    targetOffset: 6,
+    cornerType: 'cubic',
+    cornerRadius: 8
+});
+
+/**
  * Every element has reported a real size.
  *
  * Less a readiness check than a decision about which of the two triggers below
@@ -247,7 +256,7 @@ function Canvas({ direction, cells, selectedIds, onSelect, fitToken, edit }: Can
                         drawGrid={false}
                         snapLabels
                         interactive={PAPER_INTERACTIVE}
-                        linkRouting={linkRoutingStraight({ targetOffset: 6 })}
+                        linkRouting={LINK_ROUTING}
                         onElementPointerClick={({ model }) => onSelect([model.id])}
                         onElementPointerDblClick={({ model }) => editing.begin(model.id)}
                         onBlankPointerClick={() => {

--- a/mermaid-editor/react/src/mermaid/to-cells.ts
+++ b/mermaid-editor/react/src/mermaid/to-cells.ts
@@ -202,9 +202,6 @@ function endAnchor(mode: string) {
  */
 const LINK_COLOR = 'var(--link-stroke)';
 
-/** Soften the corners where dagre's vertices turn the line. */
-const CONNECTOR = { name: 'rounded', args: { radius: 8 }};
-
 const LABEL_BASE: Omit<LinkLabel, 'text'> = {
     position: 0.5,
     fontSize: 12,
@@ -252,7 +249,6 @@ export function toCells(flow: FlowGraph): MermaidCell[] {
         source: { id: edge.source, anchor },
         target: { id: edge.target, anchor },
         data: { minLen: edge.minLen },
-        connector: CONNECTOR,
         style: {
             color: LINK_COLOR,
             className: 'mermaid-link-line',


### PR DESCRIPTION
Hoists the routing preset to a module constant so it isn't rebuilt on every render, gives it `cornerType: 'cubic'` / `cornerRadius: 8`, and drops the per-link `connector` that used to round dagre's vertices — the router does it now.

Verified equivalent: the four links that bend still render one curve command each, differing only in sub-pixel corner maths, and the screenshot diff is 0.00%. Checked in the production build as well as dev — corners, all six examples, inline editing, toolbar and SVG export, no console errors. Typecheck, lint and build clean.