### PR TITLE
chore: fix .npmrc for npm v12

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All demos have `.npmrc` files configured to use the private registry at `https:/
 
 ```
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}
 ```
 

--- a/abstract-syntax-tree/js/.npmrc
+++ b/abstract-syntax-tree/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/abstract-syntax-tree/ts/.npmrc
+++ b/abstract-syntax-tree/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/ai-agent-builder/js/.npmrc
+++ b/ai-agent-builder/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/ai-agent-builder/ts/.npmrc
+++ b/ai-agent-builder/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/ai-workflow-builder/react/.npmrc
+++ b/ai-workflow-builder/react/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/alignment-and-distance-based-position-guides/js/.npmrc
+++ b/alignment-and-distance-based-position-guides/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/angles/js/.npmrc
+++ b/angles/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/bpmn-camunda-integration/js/modeler/.npmrc
+++ b/bpmn-camunda-integration/js/modeler/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/bpmn-editor/js/.npmrc
+++ b/bpmn-editor/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/bpmn-editor/ts/.npmrc
+++ b/bpmn-editor/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/bpmn-pools-swimlanes-milestones/js/.npmrc
+++ b/bpmn-pools-swimlanes-milestones/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/bpmn-pools-swimlanes-milestones/ts/.npmrc
+++ b/bpmn-pools-swimlanes-milestones/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/cables/js/.npmrc
+++ b/cables/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/cables/ts/.npmrc
+++ b/cables/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/change-element-text-alignment-in-inspector/js/.npmrc
+++ b/change-element-text-alignment-in-inspector/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/charts/js/.npmrc
+++ b/charts/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/chatbot/angular/.npmrc
+++ b/chatbot/angular/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/chatbot/react-redux-ts/.npmrc
+++ b/chatbot/react-redux-ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/chatbot/react-ts/.npmrc
+++ b/chatbot/react-ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/chatbot/vue-ts/.npmrc
+++ b/chatbot/vue-ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/clipboard-api-integration/js/.npmrc
+++ b/clipboard-api-integration/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/collapsible-minimap/js/.npmrc
+++ b/collapsible-minimap/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/comment-view/js/.npmrc
+++ b/comment-view/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/confirmation-dialogs/js/.npmrc
+++ b/confirmation-dialogs/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/connecting-nodes-by-dragging-and-dropping/js/.npmrc
+++ b/connecting-nodes-by-dragging-and-dropping/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/constellation/js/.npmrc
+++ b/constellation/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/container-distance-guides/js/.npmrc
+++ b/container-distance-guides/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/container-layout/js/.npmrc
+++ b/container-layout/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/container-layout/ts/.npmrc
+++ b/container-layout/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/context-toolbar/js/.npmrc
+++ b/context-toolbar/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/copy-paste/js/.npmrc
+++ b/copy-paste/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/corporate-organizational-chart/js/.npmrc
+++ b/corporate-organizational-chart/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/data-mapping/js/.npmrc
+++ b/data-mapping/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/data-mapping/ts/.npmrc
+++ b/data-mapping/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/data-pipeline/angular/.npmrc
+++ b/data-pipeline/angular/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/database/js/.npmrc
+++ b/database/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/database/ts/.npmrc
+++ b/database/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/decision-tree-analysis/js/.npmrc
+++ b/decision-tree-analysis/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/decision-tree/js/.npmrc
+++ b/decision-tree/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/diagram-generation-from-external-data/js/.npmrc
+++ b/diagram-generation-from-external-data/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/diagram-index/angular/.npmrc
+++ b/diagram-index/angular/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/diagram-index/react/.npmrc
+++ b/diagram-index/react/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/diagram-index/svelte/.npmrc
+++ b/diagram-index/svelte/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/diagram-index/vue/.npmrc
+++ b/diagram-index/vue/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/dialog-generator/js/.npmrc
+++ b/dialog-generator/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/distances/js/.npmrc
+++ b/distances/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/drop-stencil-element-as-shape-icon/js/.npmrc
+++ b/drop-stencil-element-as-shape-icon/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/dynamic-stencil/js/.npmrc
+++ b/dynamic-stencil/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/dynamic-tooltip-content/js/.npmrc
+++ b/dynamic-tooltip-content/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/element-grouping/js/.npmrc
+++ b/element-grouping/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/element-neighborhood-dialog-window/js/.npmrc
+++ b/element-neighborhood-dialog-window/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/element-palette-tooltips/js/.npmrc
+++ b/element-palette-tooltips/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/finite-object-pool/js/.npmrc
+++ b/finite-object-pool/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/fishbone/js/.npmrc
+++ b/fishbone/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/fishbone/ts/.npmrc
+++ b/fishbone/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/fixed-connection-points/js/.npmrc
+++ b/fixed-connection-points/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/font-awesome/js/.npmrc
+++ b/font-awesome/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/force-directed-interaction/js/.npmrc
+++ b/force-directed-interaction/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/force-directed-layout/ts/.npmrc
+++ b/force-directed-layout/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/force-directed-radial-force/js/.npmrc
+++ b/force-directed-radial-force/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/image-processor/js/.npmrc
+++ b/image-processor/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/image-processor/ts/.npmrc
+++ b/image-processor/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/infinite-paper-vs-sheets/js/.npmrc
+++ b/infinite-paper-vs-sheets/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/inspector-dynamic-element-type/js/.npmrc
+++ b/inspector-dynamic-element-type/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/inspector-for-selection/js/.npmrc
+++ b/inspector-for-selection/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/json-visualizer/js/.npmrc
+++ b/json-visualizer/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kanban/js/.npmrc
+++ b/kanban/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kanban/ts/.npmrc
+++ b/kanban/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kitchen-sink/angular/.npmrc
+++ b/kitchen-sink/angular/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kitchen-sink/js/.npmrc
+++ b/kitchen-sink/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kitchen-sink/react-js/.npmrc
+++ b/kitchen-sink/react-js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kitchen-sink/react-ts/.npmrc
+++ b/kitchen-sink/react-ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kitchen-sink/ts/.npmrc
+++ b/kitchen-sink/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kitchen-sink/vue-js/.npmrc
+++ b/kitchen-sink/vue-js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/kitchen-sink/vue-ts/.npmrc
+++ b/kitchen-sink/vue-ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/link-teleports/js/.npmrc
+++ b/link-teleports/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/list-of-links-in-inspector/js/.npmrc
+++ b/list-of-links-in-inspector/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/marketing-automation/js/.npmrc
+++ b/marketing-automation/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/marketing-automation/ts/.npmrc
+++ b/marketing-automation/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/mermaid-editor/react/.npmrc
+++ b/mermaid-editor/react/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/microservices-architecture/ts/.npmrc
+++ b/microservices-architecture/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/mind-map/js/.npmrc
+++ b/mind-map/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/mind-map/ts/.npmrc
+++ b/mind-map/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/move-elements-via-keyboard/js/.npmrc
+++ b/move-elements-via-keyboard/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/multidirectional-tree/js/.npmrc
+++ b/multidirectional-tree/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/organizational-chart/js/.npmrc
+++ b/organizational-chart/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/organizational-chart/ts/.npmrc
+++ b/organizational-chart/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/parametric-diagram/js/.npmrc
+++ b/parametric-diagram/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/pdf-export/js/.npmrc
+++ b/pdf-export/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/pert-chart/js/.npmrc
+++ b/pert-chart/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/pert-chart/ts/.npmrc
+++ b/pert-chart/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/planogram/js/.npmrc
+++ b/planogram/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/planogram/ts/.npmrc
+++ b/planogram/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/port-drag-drop/js/.npmrc
+++ b/port-drag-drop/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/port-inspector/js/.npmrc
+++ b/port-inspector/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/presentation-mode/js/.npmrc
+++ b/presentation-mode/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/rich-text-editor/js/.npmrc
+++ b/rich-text-editor/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/rich-text-editor/ts/.npmrc
+++ b/rich-text-editor/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/sankey-diagram/js/.npmrc
+++ b/sankey-diagram/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/saving-and-loading-using-file-system-access-api/js/.npmrc
+++ b/saving-and-loading-using-file-system-access-api/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/scada/js/.npmrc
+++ b/scada/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/searchable-sitemap/js/.npmrc
+++ b/searchable-sitemap/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/selection-alignment/js/.npmrc
+++ b/selection-alignment/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/shape-builder/js/.npmrc
+++ b/shape-builder/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/sheet-cutting/js/.npmrc
+++ b/sheet-cutting/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/sheet-cutting/ts/.npmrc
+++ b/sheet-cutting/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/shortest-path-algorithm/js/.npmrc
+++ b/shortest-path-algorithm/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/stencil-favorite-in-use-groups/js/.npmrc
+++ b/stencil-favorite-in-use-groups/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/stencil-theme-picker/js/.npmrc
+++ b/stencil-theme-picker/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/stencil-vs-diagram-elements/js/.npmrc
+++ b/stencil-vs-diagram-elements/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tabs/angular/.npmrc
+++ b/tabs/angular/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tabs/react/.npmrc
+++ b/tabs/react/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tabs/svelte/.npmrc
+++ b/tabs/svelte/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tabs/vue/.npmrc
+++ b/tabs/vue/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/team-order/js/.npmrc
+++ b/team-order/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/team-order/ts/.npmrc
+++ b/team-order/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/text-position-based-on-space-availability/js/.npmrc
+++ b/text-position-based-on-space-availability/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/the-archimate-enterprise-architecture-modeling-language/js/.npmrc
+++ b/the-archimate-enterprise-architecture-modeling-language/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/theory-of-change/js/.npmrc
+++ b/theory-of-change/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/theory-of-change/ts/.npmrc
+++ b/theory-of-change/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/timeline/js/.npmrc
+++ b/timeline/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/timeline/ts/.npmrc
+++ b/timeline/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tokens/js/.npmrc
+++ b/tokens/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tokens/ts/.npmrc
+++ b/tokens/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/touch-gestures/js/.npmrc
+++ b/touch-gestures/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tournament-brackets/js/.npmrc
+++ b/tournament-brackets/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/translate-connected-links-in-selection/js/.npmrc
+++ b/translate-connected-links-in-selection/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tree-builder/js/.npmrc
+++ b/tree-builder/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tree-collapse-expand/js/.npmrc
+++ b/tree-collapse-expand/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tree-designer/js/.npmrc
+++ b/tree-designer/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tree-designer/ts/.npmrc
+++ b/tree-designer/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tree-graph-and-cycles/js/.npmrc
+++ b/tree-graph-and-cycles/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tree-stencil/js/.npmrc
+++ b/tree-stencil/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/tree-stencil/ts/.npmrc
+++ b/tree-stencil/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/ui-popup/js/.npmrc
+++ b/ui-popup/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/uml-class-diagrams/js/.npmrc
+++ b/uml-class-diagrams/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/uml-class-shape-inspector/js/.npmrc
+++ b/uml-class-shape-inspector/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/upload-image-to-stencil/js/.npmrc
+++ b/upload-image-to-stencil/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/vector-editor/js/.npmrc
+++ b/vector-editor/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/view-edit-mode/js/.npmrc
+++ b/view-edit-mode/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-bpmn-export/js/.npmrc
+++ b/visio-bpmn-export/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-bpmn-export/ts/.npmrc
+++ b/visio-bpmn-export/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-bpmn-import/js/.npmrc
+++ b/visio-bpmn-import/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-bpmn-import/ts/.npmrc
+++ b/visio-bpmn-import/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-default-import/js/.npmrc
+++ b/visio-default-import/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-flowchart-import/js/.npmrc
+++ b/visio-flowchart-import/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-flowchart-import/ts/.npmrc
+++ b/visio-flowchart-import/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-org-chart-import/js/.npmrc
+++ b/visio-org-chart-import/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/visio-org-chart-import/ts/.npmrc
+++ b/visio-org-chart-import/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/workflow-builder/js/.npmrc
+++ b/workflow-builder/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/workflow-builder/ts/.npmrc
+++ b/workflow-builder/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/yamazumi-3d/js/.npmrc
+++ b/yamazumi-3d/js/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}

--- a/yamazumi-3d/ts/.npmrc
+++ b/yamazumi-3d/ts/.npmrc
@@ -1,3 +1,3 @@
 @joint:registry=https://npm.jointjs.com
-always-auth=true
+allow-remote=all
 //npm.jointjs.com/:_authToken=${JOINTJS_NPM_TOKEN}


### PR DESCRIPTION
- `always-auth` setting has been removed in NPM v12 and now causes an error to be thrown when it is present
- `allow-remote` setting has been added in NPM v12 with a strict default. `allow-remote=all` is required to allow the previous behavior (redirecting from our registry to the standard `registry.npmjs.org` for packages which cannot be found on our registry)