### PR TITLE
fix: update the react BPMN editor to @joint/react-plus 4.3.2

### DIFF
--- a/bpmn-editor/react/package.json
+++ b/bpmn-editor/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@joint/demo-bpmn-editor-react",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "type": "module",
     "private": true,
     "scripts": {
@@ -11,10 +11,10 @@
         "test": "npm run typecheck"
     },
     "dependencies": {
-        "@joint/format-bpmn-export": "4.3.1",
-        "@joint/format-bpmn-import": "4.3.1",
-        "@joint/plus": "4.3.1",
-        "@joint/react-plus": "^4.3.1",
+        "@joint/format-bpmn-export": "4.3.2",
+        "@joint/format-bpmn-import": "4.3.2",
+        "@joint/plus": "4.3.2",
+        "@joint/react-plus": "4.3.2",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-select": "^2.3.7",

--- a/bpmn-editor/react/src/hooks/use-view-interactions.ts
+++ b/bpmn-editor/react/src/hooks/use-view-interactions.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { dia } from '@joint/plus';
-import { usePaper, useSelectionCollection, useOnPaperEvents } from '@joint/react-plus';
+import { useSelectionCollection, useOnPaperEvents } from '@joint/react-plus';
 import { addEffect, removeEffect, EffectType } from '../effects';
 import { isForkEvent, getPoolParent, resolveDefaultLinkType, isSwimlane, isPool, isActivity } from '../utils';
 import { PlaceholderShapeTypes } from '../shapes/link-config';
@@ -14,7 +14,6 @@ export function useViewInteractions() {
 
     const selection = useSelectionCollection();
     const { collection } = selection;
-    const { paper } = usePaper();
 
     // The built-in `ctrl`/`cmd`+click toggles cells in the selection. Keep
     // the cherry-picking scoped: only elements, and never mix elements from
@@ -41,21 +40,6 @@ export function useViewInteractions() {
     }, [collection]);
 
     useOnPaperEvents({
-
-        // The react paper keeps a link hidden until its end views are ready,
-        // but for link-to-link connections the readiness check never resolves
-        // (it only looks the end up among the elements) — unhide such links
-        // once their end views exist.
-        // TODO: remove when fixed upstream.
-        'render:done': () => {
-            if (!paper) return;
-            for (const link of paper.model.getLinks()) {
-                const view = link.findView(paper);
-                if (view?.el.style.visibility === 'hidden') {
-                    view.el.style.visibility = '';
-                }
-            }
-        },
 
         onCellPointerUp: ({ model, event }) => {
             if (isForkEvent(event) && model.graph) {


### PR DESCRIPTION
Updates the demo to `@joint/*` 4.3.2 and removes the `render:done` workaround for link-to-link visibility — fixed upstream in clientIO/joint#3478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)