### PR TITLE
docs: link the react variant from the BPMN editor README

### DIFF
--- a/bpmn-editor/README.md
+++ b/bpmn-editor/README.md
@@ -1,11 +1,12 @@
 # JointJS+: BPMN Editor <a href="https://www.jointjs.com/jointjs-plus"><img src="../jointjs-plus-badge.svg" alt="JointJS+" width="123" align="right" /></a>
 
-The BPMN demo app showcases a standardized method of modeling a business process from beginning to end. It's written in TypeScript but can be seamlessly integrated with React, Vue, Angular, Svelte, or LightningJS.
+The BPMN demo app showcases a standardized method of modeling a business process from beginning to end. It's available as a React app (built with [`@joint/react-plus`](https://docs.jointjs.com/react)) and in plain TypeScript/JavaScript, which can be seamlessly integrated with Vue, Angular, Svelte, or LightningJS.
 
 This demo is also available online at [jointjs.com](https://jointjs.com/demos/bpmn-editor).
 
 ## Available Versions
 
+- [React](./react/)
 - [JavaScript](./js/)
 - [TypeScript](./ts/)
 


### PR DESCRIPTION
The top-level BPMN editor README did not mention the react variant — adds it to the versions list and the intro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)