### PR TITLE
fix: drop the drag paper popover workaround in the react BPMN editor

### DIFF
--- a/bpmn-editor/react/package.json
+++ b/bpmn-editor/react/package.json
@@ -13,8 +13,8 @@
     "dependencies": {
         "@joint/format-bpmn-export": "4.3.2",
         "@joint/format-bpmn-import": "4.3.2",
-        "@joint/plus": "4.3.2",
-        "@joint/react-plus": "4.3.2",
+        "@joint/plus": "4.3.3",
+        "@joint/react-plus": "4.3.3",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-select": "^2.3.7",

--- a/bpmn-editor/react/src/dnd/stencil.ts
+++ b/bpmn-editor/react/src/dnd/stencil.ts
@@ -16,7 +16,6 @@ export function onStencilElementDragStart({ model, event, dropArea, paper, dragP
     const cloneView = dragPaper.findViewByModel(model) as dia.ElementView;
     const { x, y } = dropArea.center();
 
-    showDragPaper(dragPaper);
     setStencilEvent(event, true);
 
     if (isSwimlane(model)) {
@@ -26,29 +25,6 @@ export function onStencilElementDragStart({ model, event, dropArea, paper, dragP
     } else {
         onElementDragStart(paper, cloneView, event, x, y);
     }
-}
-
-/**
- * Puts the drag paper in the top layer.
- *
- * Works around a bug in `@joint/react-plus` (clientIO/joint-plus#803): the
- * drag paper is given `popover="manual"` and its UA popover styling is
- * neutralised, but nothing ever calls `showPopover()` on the React drag path,
- * so it is not in the top layer. It renders as an ordinary absolutely
- * positioned child of the body at `z-index: auto`, which the stencil
- * container paints over — the clone disappears behind the palette.
- *
- * Delete this once the library shows it itself.
- */
-function showDragPaper(dragPaper: dia.Paper) {
-    const { el } = dragPaper;
-
-    // The types promise `showPopover`; a browser without the API is the case
-    // this guards.
-    if (typeof el.showPopover !== 'function') return;
-    if (!el.hasAttribute('popover') || el.matches(':popover-open')) return;
-
-    el.showPopover();
 }
 
 /**


### PR DESCRIPTION
Bumps the react BPMN editor to `@joint/plus` / `@joint/react-plus` 4.3.3 and removes the local workaround that is no longer needed.

`<Stencil />` in 4.3.3 shows the drag paper as a popover itself, so the dragged clone renders in the browser top layer without the demo calling `showPopover()` on the drag paper element.

## Test plan

- Drag an element out of the stencil and confirm the clone stays above the palette instead of disappearing behind it.

