### PR TITLE
fix: make the shikaku board usable on a touch screen

### DIFF
--- a/shikaku/react/README.md
+++ b/shikaku/react/README.md
@@ -19,7 +19,8 @@ React. Pick a size and a difficulty and the generator cuts you a fresh board.
   and counting by eye is the tedious part. A rectangle that cannot be placed
   previews in dashed red, and a pill says why. A single number of `1` is placed
   with a plain click.
-- **Remove a rectangle**: right-click anywhere inside it.
+- **Remove a rectangle**: click or right-click anywhere inside it. A click is
+  what makes this reachable on a touch screen, where there is no right button.
 - **Undo / redo**: `Ctrl`/`⌘` + `Z` and `Ctrl`/`⌘` + `Shift` + `Z`, or the
   toolbar buttons. A new move drops whatever was undone.
 - **Escape** abandons the rectangle being dragged.

--- a/shikaku/react/src/canvas/use-draw-region.ts
+++ b/shikaku/react/src/canvas/use-draw-region.ts
@@ -19,7 +19,7 @@
  *   so commit changes nothing but the opacity.
  */
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { g } from '@joint/plus';
+import { g, type dia } from '@joint/plus';
 import { useOnKeyboardEvents, useRegion } from '@joint/react-plus';
 import type { PaperEventHandler, PaperEventMap } from '@joint/react-plus';
 import { pickColor } from '@/puzzle/colors';
@@ -35,7 +35,10 @@ export interface DrawRegionApi {
     readonly pending: PendingRect | null;
     /** Why the rectangle being dragged cannot be placed, or `null`. */
     readonly rejection: RejectReason | null;
-    readonly handlers: Pick<PaperEventMap, 'onElementPointerDown' | 'onElementContextMenu'>;
+    readonly handlers: Pick<
+        PaperEventMap,
+        'onElementPointerDown' | 'onElementPointerClick' | 'onElementContextMenu'
+    >;
 }
 
 interface Evaluated {
@@ -59,9 +62,16 @@ export function useDrawRegion(puzzle: Puzzle, game: GameApi): DrawRegionApi {
 
     const onElementPointerDown = useCallback<PaperEventHandler<'onElementPointerDown'>>(
         ({ model, event }) => {
-            // A right-press also reaches `element:pointerdown`; leave it to
-            // `onElementContextMenu`.
-            if (event.button !== 0) return;
+            /*
+             * A right-press also reaches `element:pointerdown`; leave it to
+             * `onElementContextMenu`.
+             *
+             * `?? 0` because a touch has no button at all: the paper maps
+             * `touchstart` to this same handler, and a `TouchEvent` carries no
+             * `button` property. Comparing it to 0 directly turned every touch
+             * into a right-press and made the demo unusable on a phone.
+             */
+            if ((event.button ?? 0) !== 0) return;
 
             // Pressing on a rectangle that is already placed does nothing.
             // Every rectangle drawn from there would overlap it, and a drag
@@ -119,18 +129,44 @@ export function useDrawRegion(puzzle: Puzzle, game: GameApi): DrawRegionApi {
         [clues, cols, rows, regions, place, startRectangleRegion]
     );
 
-    const onElementContextMenu = useCallback<PaperEventHandler<'onElementContextMenu'>>(
-        ({ model, event }) => {
-            event.preventDefault();
-            // Rectangles are drawn over the squares, so a right-press inside
-            // one lands on the rectangle itself and its element id names it. On
-            // a bare square there is nothing to remove.
+    /**
+     * Takes a rectangle off the board.
+     *
+     * Rectangles are drawn over the squares, so a press inside one lands on the
+     * rectangle itself and its element id names it. On a bare square there is
+     * nothing to remove.
+     */
+    const removeUnder = useCallback(
+        (model: dia.Element) => {
             const data = model.get('data') as CellData;
             if (data.kind !== 'region') return;
             remove(String(model.id));
             setRejection(null);
         },
         [remove]
+    );
+
+    const onElementContextMenu = useCallback<PaperEventHandler<'onElementContextMenu'>>(
+        ({ model, event }) => {
+            event.preventDefault();
+            removeUnder(model);
+        },
+        [removeUnder]
+    );
+
+    /*
+     * A plain click removes a rectangle too. Right-click is the natural gesture
+     * with a mouse and the only one a phone cannot make, and a rectangle is the
+     * one thing on this board a click could mean — pressing one never starts a
+     * drag, since every rectangle drawn from inside it would overlap. Undo is a
+     * keystroke away if it was not meant.
+     *
+     * A drag past the paper's `clickThreshold` is not a click, so placing a
+     * rectangle never removes the one under where the finger came up.
+     */
+    const onElementPointerClick = useCallback<PaperEventHandler<'onElementPointerClick'>>(
+        ({ model }) => removeUnder(model),
+        [removeUnder]
     );
 
     const cancelDrag = useCallback(() => {
@@ -152,8 +188,8 @@ export function useDrawRegion(puzzle: Puzzle, game: GameApi): DrawRegionApi {
     useOnKeyboardEvents({ escape: () => cancelDrag() });
 
     const handlers = useMemo(
-        () => ({ onElementPointerDown, onElementContextMenu }),
-        [onElementPointerDown, onElementContextMenu]
+        () => ({ onElementPointerDown, onElementPointerClick, onElementContextMenu }),
+        [onElementPointerDown, onElementPointerClick, onElementContextMenu]
     );
 
     return { pending, rejection, handlers };

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -127,6 +127,12 @@ body,
 
 .toolbar-group {
     display: flex;
+    /*
+     * Wraps for the same reason the toolbar does. Without it a group is one
+     * unbreakable flex item, and on a phone the widest of them runs past the
+     * toolbar's padding and out to the edge of the screen.
+     */
+    flex-wrap: wrap;
     align-items: center;
     gap: 8px;
 }
@@ -320,6 +326,19 @@ button.icon svg {
 /* The squares never move, so the pointer should say "draw", not "drag". */
 .board-paper .joint-cell {
     cursor: crosshair;
+}
+
+/*
+ * Every touch on the board is a rectangle being drawn, so none of it is the
+ * browser's to interpret. Without this the browser claims the gesture for
+ * scrolling and cancels the pointer stream the rubber band is listening to,
+ * and nothing can be drawn on a phone at all.
+ */
+.board-stage {
+    touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
 }
 
 /*

--- a/shikaku/react/src/toolbar/help-dialog.tsx
+++ b/shikaku/react/src/toolbar/help-dialog.tsx
@@ -48,7 +48,7 @@ export function HelpDialog({ open, onClose }: HelpDialogProps) {
                     placed.
                 </li>
                 <li>
-                    <b>Remove</b> — right-click inside a rectangle.
+                    <b>Remove</b> — click or right-click inside a rectangle.
                 </li>
                 <li>
                     <b>Escape</b> — abandon the rectangle you are dragging.


### PR DESCRIPTION
Follow-up to #50 — this was pushed a few minutes after that PR was squashed,
so it missed the merge.

Nothing could be drawn on a phone at all. Three separate things were wrong.

**Every touch was read as a right-press.** The paper maps `touchstart` to the
same `element:pointerdown` handler as a mouse press (`Paper.mjs:549`), and a
`TouchEvent` carries no `button` — so the guard meant to let a right-press
through to the context menu was evaluating `undefined !== 0` and returning
early. Now `(event.button ?? 0) !== 0`.

**The board did not claim the gesture.** Without `touch-action: none` the
browser takes the drag for scrolling and cancels the pointer stream the rubber
band listens to. The stage sets it now, with the selection and callout
suppression that goes with it.

**Removing a rectangle was right-click only**, which a touch screen cannot do.
A plain click removes one too. Pressing a placed rectangle never started a drag
— every rectangle drawn from inside one would overlap — so a click there had no
other meaning. A drag past the paper's `clickThreshold` is not a click, so
placing a rectangle never removes the one under where the finger came up, and
undo covers a misfire.

Also lets a `.toolbar-group` wrap: each was one unbreakable flex item, and on a
390 px screen the widest ran past the toolbar's padding to the edge.

## Verified

Emulated iPhone 13, touch dispatched over CDP:

| | before | after |
|---|---|---|
| touch drag | nothing at all | preview appears, count reads `8`, rectangle commits |
| tap a rectangle | nothing | removed |
| `New puzzle` right edge | flush at 397 px, clipped | 112 px, clear of the padding |

Desktop unchanged: dragging still places, left-click removes, undo restores,
right-click still removes, a click on a bare square still places a `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)