### PR TITLE
feat: a New puzzle dialog, and boards that start with their 1s filled in

### DIFF
--- a/shikaku/react/README.md
+++ b/shikaku/react/README.md
@@ -13,6 +13,9 @@ React. Pick a size and a difficulty and the generator cuts you a fresh board.
 
 ## Playing
 
+- A board starts with its `1`s filled in, drawn gray and without a number — a 1
+  has only one rectangle it could ever be. They cannot be removed, and *Fill in
+  the 1s* in the New puzzle dialog (or `?ones=off`) leaves them to you.
 - **Draw a rectangle**: press on a square and drag. The rectangle grows with the
   pointer, in the color it will keep, and the count of squares under it is
   drawn large in the corner of the canvas — the game is hitting an exact number,
@@ -95,6 +98,10 @@ The query string wins over the environment, and anything left unnamed falls back
 to the default 10x10 medium board — so `?seed=1234` on its own is enough. Sizes
 are held to the same 5-25 limits as the toolbar's inputs, and unusable values
 are ignored rather than argued with.
+
+`ones=off` leaves the 1s as numbers for the player to draw rather than starting
+with them filled in. It is the one setting the share link carries beyond size,
+difficulty and seed, and only when it is off.
 
 `clock=off` (or `no`, `false`, `0`, or `VITE_CLOCK=off`) stops the timer before
 it starts. Naming a board makes everything on screen reproducible except the

--- a/shikaku/react/README.md
+++ b/shikaku/react/README.md
@@ -24,6 +24,8 @@ React. Pick a size and a difficulty and the generator cuts you a fresh board.
 - **Undo / redo**: `Ctrl`/`⌘` + `Z` and `Ctrl`/`⌘` + `Shift` + `Z`, or the
   toolbar buttons. A new move drops whatever was undone.
 - **Escape** abandons the rectangle being dragged.
+- **New puzzle** generates a board at the current size; the arrow beside it
+  opens a dialog holding the size and difficulty.
 - The **help** button in the toolbar opens the rules and the controls, the one
   next to it switches between the light and dark themes, and the **share**
   button copies a link that reopens the same board.

--- a/shikaku/react/src/app.tsx
+++ b/shikaku/react/src/app.tsx
@@ -50,9 +50,12 @@ export function App() {
               * graph, and an empty game. Remounting says all of that at once.
               */}
             <ShikakuGame
-                key={`${puzzle.seed}:${puzzle.cols}x${puzzle.rows}`}
+                // The key includes what the board was built with, not just what
+                // was generated: turning the 1s off is a different element set.
+                key={`${puzzle.seed}:${puzzle.cols}x${puzzle.rows}:${request.fillOnes}`}
                 puzzle={puzzle}
                 clock={INITIAL.clock}
+                fillOnes={request.fillOnes}
                 settings={settings}
                 onNewPuzzle={onNewPuzzle}
             />

--- a/shikaku/react/src/app.tsx
+++ b/shikaku/react/src/app.tsx
@@ -30,9 +30,18 @@ export function App() {
      */
     const puzzle = useMemo(() => generatePuzzle(request), [request]);
 
-    const onNewPuzzle = useCallback(() => {
-        setRequest({ ...settings, seed: randomSeed() });
-    }, [settings]);
+    /*
+     * Takes the settings to use, because the dialog changes them and generates
+     * in one press: passing them in avoids reading a `settings` state that has
+     * not been committed yet.
+     */
+    const onNewPuzzle = useCallback(
+        (next: Settings = settings) => {
+            setSettings(next);
+            setRequest({ ...next, seed: randomSeed() });
+        },
+        [settings]
+    );
 
     return (
         <div className="app">
@@ -45,7 +54,6 @@ export function App() {
                 puzzle={puzzle}
                 clock={INITIAL.clock}
                 settings={settings}
-                onSettingsChange={setSettings}
                 onNewPuzzle={onNewPuzzle}
             />
         </div>

--- a/shikaku/react/src/board-request.test.ts
+++ b/shikaku/react/src/board-request.test.ts
@@ -18,13 +18,14 @@ describe('resolveBoardRequest', () => {
             difficulty: DEFAULT_DIFFICULTY,
             seed: 42,
             clock: true,
+            fillOnes: true,
         });
     });
 
     it('reads a board out of a query string', () => {
         expect(
             resolveBoardRequest({ search: '?seed=1234&width=12&height=8&difficulty=hard' })
-        ).toEqual({ cols: 12, rows: 8, difficulty: 'hard', seed: 1234, clock: true });
+        ).toEqual({ cols: 12, rows: 8, difficulty: 'hard', seed: 1234, clock: true, fillOnes: true });
     });
 
     it('accepts cols / rows as aliases', () => {
@@ -39,7 +40,14 @@ describe('resolveBoardRequest', () => {
             resolveBoardRequest({
                 env: { VITE_SEED: '7', VITE_WIDTH: '15', VITE_HEIGHT: '15', VITE_DIFFICULTY: 'easy' },
             })
-        ).toEqual({ cols: 15, rows: 15, difficulty: 'easy', seed: 7, clock: true });
+        ).toEqual({
+            cols: 15,
+            rows: 15,
+            difficulty: 'easy',
+            seed: 7,
+            clock: true,
+            fillOnes: true,
+        });
     });
 
     it('lets the query string win over the environment', () => {
@@ -67,6 +75,7 @@ describe('resolveBoardRequest', () => {
             difficulty: DEFAULT_DIFFICULTY,
             seed: 42,
             clock: true,
+            fillOnes: true,
         });
     });
 
@@ -82,6 +91,18 @@ describe('resolveBoardRequest', () => {
         );
     });
 
+    it('leaves the 1s to the player on request', () => {
+        for (const value of ['off', 'no', 'false', '0']) {
+            expect(
+                resolveBoardRequest({ search: `?ones=${value}`, fallbackSeed: seed }).fillOnes
+            ).toBe(false);
+        }
+        expect(resolveBoardRequest({ env: { VITE_ONES: 'off' }, fallbackSeed: seed }).fillOnes).toBe(
+            false
+        );
+        expect(resolveBoardRequest({ fallbackSeed: seed }).fillOnes).toBe(true);
+    });
+
     it('normalizes a seed to 32 bits unsigned, as the generator does', () => {
         expect(resolveBoardRequest({ search: '?seed=-1' })).toMatchObject({ seed: 4294967295 });
     });
@@ -94,7 +115,7 @@ describe('resolveBoardRequest', () => {
 });
 
 describe('boardUrl', () => {
-    const board = { cols: 12, rows: 8, difficulty: 'hard' as const, seed: 1234 };
+    const board = { cols: 12, rows: 8, difficulty: 'hard' as const, seed: 1234, fillOnes: true };
 
     it('writes everything resolveBoardRequest reads', () => {
         const url = boardUrl(board, 'https://example.com/shikaku/');
@@ -102,6 +123,11 @@ describe('boardUrl', () => {
             'https://example.com/shikaku/?seed=1234&width=12&height=8&difficulty=hard'
         );
         expect(resolveBoardRequest({ search: new URL(url).search })).toMatchObject(board);
+    });
+
+    it('names the 1s only when they are turned off', () => {
+        expect(boardUrl(board, 'https://example.com/')).not.toContain('ones=');
+        expect(boardUrl({ ...board, fillOnes: false }, 'https://example.com/')).toContain('ones=off');
     });
 
     it('drops whatever opened the page', () => {

--- a/shikaku/react/src/board-request.ts
+++ b/shikaku/react/src/board-request.ts
@@ -18,6 +18,9 @@
  * at that seed. Without a seed anywhere, a random one is drawn, which is the
  * ordinary case.
  *
+ * `ones=off` leaves the 1s as numbers for the player to draw, rather than
+ * starting with them filled in.
+ *
  * `clock=off` stops the timer before it starts. Naming a board makes everything
  * on screen reproducible except the clock, which would tick on regardless — so
  * this is what makes a screenshot of the demo comparable with the one taken
@@ -34,6 +37,8 @@ export interface BoardRequest {
     readonly seed: number;
     /** `false` freezes the timer at zero. See `clock=off`. */
     readonly clock: boolean;
+    /** `false` leaves the 1s as numbers to be drawn. See `ones=off`. */
+    readonly fillOnes: boolean;
 }
 
 export const DEFAULT_COLS = 10;
@@ -82,7 +87,7 @@ function readDifficulty(read: Read, ...names: readonly string[]): Difficulty | n
  * and so is anything the player has placed. What is shared is the puzzle.
  */
 export function boardUrl(
-    board: Pick<BoardRequest, 'cols' | 'rows' | 'difficulty' | 'seed'>,
+    board: Pick<BoardRequest, 'cols' | 'rows' | 'difficulty' | 'seed' | 'fillOnes'>,
     base: string
 ): string {
     const url = new URL(base);
@@ -93,6 +98,8 @@ export function boardUrl(
     url.searchParams.set('width', String(board.cols));
     url.searchParams.set('height', String(board.rows));
     url.searchParams.set('difficulty', board.difficulty);
+    // Only when it differs from the default, so an ordinary link stays short.
+    if (!board.fillOnes) url.searchParams.set('ones', 'off');
     return url.toString();
 }
 
@@ -126,6 +133,7 @@ export function resolveBoardRequest({
         readDifficulty(query, 'difficulty') ?? readDifficulty(environment, 'VITE_DIFFICULTY');
     const seed = readNumber(query, 'seed') ?? readNumber(environment, 'VITE_SEED');
     const clock = readOff(query, 'clock') ?? readOff(environment, 'VITE_CLOCK');
+    const fillOnes = readOff(query, 'ones') ?? readOff(environment, 'VITE_ONES');
 
     return {
         cols: cols === null ? DEFAULT_COLS : clampSide(cols),
@@ -136,5 +144,6 @@ export function resolveBoardRequest({
         // produce a board, just not the one the caller named.
         seed: seed === null ? fallbackSeed() : seed >>> 0,
         clock: clock ?? true,
+        fillOnes: fillOnes ?? true,
     };
 }

--- a/shikaku/react/src/canvas/cells.ts
+++ b/shikaku/react/src/canvas/cells.ts
@@ -49,6 +49,14 @@ export interface RegionData {
      */
     readonly rect: Rect;
     readonly clueIndex: number | null;
+    /**
+     * A rectangle the board came with rather than one the player drew.
+     *
+     * Only the 1s: a clue of 1 has exactly one rectangle it can ever be, so
+     * there is no decision in it. Drawn gray and without its number, and the
+     * player cannot take it away.
+     */
+    readonly given: boolean;
     /** True while the rectangle is still being dragged out. */
     readonly pending: boolean;
     /**
@@ -91,10 +99,43 @@ export function isRegionData(data: CellData | undefined): data is RegionData {
     return data?.kind === 'region';
 }
 
+/**
+ * Everything the board starts with: a square per cell, and a rectangle for
+ * every clue of 1.
+ *
+ * The givens are seeded rather than placed, which is what keeps them off the
+ * undo stack — `<Diagram history>` records what happens after the graph is
+ * created, not what it was created with.
+ */
+export function buildBoard(puzzle: Puzzle, fillOnes: boolean): BoardElement[] {
+    const givens = puzzle.clues.flatMap((clue, clueIndex) => {
+        if (!fillOnes || clue.value !== 1) return [];
+        const rect = { x: clue.x, y: clue.y, w: 1, h: 1 };
+        return [
+            buildRegionCell({
+                id: regionId(rect),
+                rect,
+                clueIndex,
+                given: true,
+                // Givens are gray, so the palette index is never read. -1 keeps
+                // it out of the neighbor comparison `pickColor` runs.
+                color: -1,
+                pending: false,
+            }),
+        ];
+    });
+    return [...buildSquares(puzzle, fillOnes), ...givens];
+}
+
 /** One element per square, in reading order. */
-export function buildSquares(puzzle: Puzzle): BoardElement[] {
+function buildSquares(puzzle: Puzzle, fillOnes: boolean): BoardElement[] {
     const clueAt = new Map<string, number>();
-    for (const clue of puzzle.clues) clueAt.set(cellId(clue.x, clue.y), clue.value);
+    for (const clue of puzzle.clues) {
+        // A filled-in 1 is drawn by its given rectangle, which carries no
+        // number; left unfilled it is an ordinary clue like any other.
+        if (fillOnes && clue.value === 1) continue;
+        clueAt.set(cellId(clue.x, clue.y), clue.value);
+    }
 
     const squares: BoardElement[] = [];
     for (let y = 0; y < puzzle.rows; y++) {
@@ -121,6 +162,8 @@ export interface RegionCellOptions {
     readonly rejected?: boolean;
     /** Index into `Puzzle.clues`, for a placed rectangle. */
     readonly clueIndex?: number;
+    /** See {@link RegionData.given}. */
+    readonly given?: boolean;
     /** Grid position and value of the number inside, for a placed rectangle. */
     readonly clue?: { readonly value: number; readonly x: number; readonly y: number };
 }
@@ -132,6 +175,7 @@ export function buildRegionCell({
     pending,
     rejected = false,
     clueIndex,
+    given = false,
     clue,
 }: RegionCellOptions): BoardElement {
     const box = rectToBox(rect);
@@ -147,6 +191,7 @@ export function buildRegionCell({
             color,
             rect,
             clueIndex: clueIndex ?? null,
+            given,
             pending,
             rejected,
             width: box.width,

--- a/shikaku/react/src/canvas/render-cell.tsx
+++ b/shikaku/react/src/canvas/render-cell.tsx
@@ -85,8 +85,17 @@ function Region({ color, given, pending, rejected, width, height, clue }: Region
             ? 'var(--reject-stroke)'
             : `var(--region-stroke-${color})`;
 
+    /*
+     * The pointer says what a press here would do. A placed rectangle can be
+     * clicked away, so it gets the hand; a given cannot be touched at all, so
+     * it gets nothing. The crosshair belongs to the squares, where a press
+     * starts drawing — claiming it over a rectangle that cannot be drawn on
+     * would be a lie.
+     */
+    const cursor = given ? 'default' : pending ? 'crosshair' : 'pointer';
+
     return (
-        <>
+        <g style={{ cursor }}>
             <rect
                 width={width}
                 height={height}
@@ -99,7 +108,7 @@ function Region({ color, given, pending, rejected, width, height, clue }: Region
             />
             {/* A given carries no number: a 1 has only ever one shape. */}
             {clue && !given && <ClueText x={clue.x} y={clue.y} value={clue.value} />}
-        </>
+        </g>
     );
 }
 

--- a/shikaku/react/src/canvas/render-cell.tsx
+++ b/shikaku/react/src/canvas/render-cell.tsx
@@ -63,7 +63,9 @@ function Square({ clue }: SquareData) {
  *
  * A placed rectangle is opaque and carries its own number, so it hides the
  * squares it covers outright — which is what makes it read as one shape rather
- * than as the squares it was drawn over.
+ * than as the squares it was drawn over. A *given* — the board's own 1s — is
+ * gray and carries no number, because a clue of 1 has only one rectangle it
+ * could ever be.
  *
  * A pending one is translucent instead, and draws nothing of its own: the
  * numbers under it are the ones the player is still reading, and they have to
@@ -71,9 +73,17 @@ function Square({ clue }: SquareData) {
  * belongs to the readout above the board — a label inside the shape is one more
  * thing to read in exactly the place the shape is already saying something.
  */
-function Region({ color, pending, rejected, width, height, clue }: RegionData) {
-    const fill = rejected ? 'var(--reject-fill)' : `var(--region-fill-${color})`;
-    const stroke = rejected ? 'var(--reject-stroke)' : `var(--region-stroke-${color})`;
+function Region({ color, given, pending, rejected, width, height, clue }: RegionData) {
+    const fill = given
+        ? 'var(--given-fill)'
+        : rejected
+            ? 'var(--reject-fill)'
+            : `var(--region-fill-${color})`;
+    const stroke = given
+        ? 'var(--given-stroke)'
+        : rejected
+            ? 'var(--reject-stroke)'
+            : `var(--region-stroke-${color})`;
 
     return (
         <>
@@ -87,7 +97,8 @@ function Region({ color, pending, rejected, width, height, clue }: RegionData) {
                 strokeDasharray={rejected ? REJECT_DASH : undefined}
                 style={{ fill, stroke }}
             />
-            {clue && <ClueText x={clue.x} y={clue.y} value={clue.value} />}
+            {/* A given carries no number: a 1 has only ever one shape. */}
+            {clue && !given && <ClueText x={clue.x} y={clue.y} value={clue.value} />}
         </>
     );
 }

--- a/shikaku/react/src/canvas/use-draw-region.ts
+++ b/shikaku/react/src/canvas/use-draw-region.ts
@@ -139,7 +139,7 @@ export function useDrawRegion(puzzle: Puzzle, game: GameApi): DrawRegionApi {
     const removeUnder = useCallback(
         (model: dia.Element) => {
             const data = model.get('data') as CellData;
-            if (data.kind !== 'region') return;
+            if (data.kind !== 'region' || data.given) return;
             remove(String(model.id));
             setRejection(null);
         },

--- a/shikaku/react/src/canvas/use-fit-to-content.ts
+++ b/shikaku/react/src/canvas/use-fit-to-content.ts
@@ -34,8 +34,15 @@ import { useLayoutEffect, useRef } from 'react';
 import { usePaper } from '@joint/react-plus';
 import type { dia } from '@joint/plus';
 
-/** Space left between the board and the edge of its container, in pixels. */
-const PADDING = 40;
+/**
+ * Space left around the board, in pixels.
+ *
+ * Less at the sides than above and below, and much less than it used to be.
+ * The vertical band earns its keep — the count sits in it, and the status line
+ * — but nothing lives at the sides, and on a phone the board is width-limited,
+ * so every pixel spent there comes straight off the squares.
+ */
+const PADDING: dia.Padding = { top: 40, bottom: 40, left: 14, right: 14 };
 
 /**
  * How far the board may be blown up.

--- a/shikaku/react/src/game/game.tsx
+++ b/shikaku/react/src/game/game.tsx
@@ -33,11 +33,10 @@ export interface ShikakuGameProps {
     /** `false` freezes the timer at zero, for a reproducible screenshot. */
     readonly clock: boolean;
     readonly settings: Settings;
-    readonly onSettingsChange: (settings: Settings) => void;
-    readonly onNewPuzzle: () => void;
+    readonly onNewPuzzle: (settings?: Settings) => void;
 }
 
-function Playing({ puzzle, clock, settings, onSettingsChange, onNewPuzzle }: ShikakuGameProps) {
+function Playing({ puzzle, clock, settings, onNewPuzzle }: ShikakuGameProps) {
     const game = useGame(puzzle);
     // Stops the moment the last square is covered, so the toast can report the
     // time the board actually took — and never starts at all when the clock has
@@ -50,7 +49,6 @@ function Playing({ puzzle, clock, settings, onSettingsChange, onNewPuzzle }: Shi
                 puzzle={puzzle}
                 game={game}
                 settings={settings}
-                onSettingsChange={onSettingsChange}
                 onNewPuzzle={onNewPuzzle}
             />
             <main className="board-area">
@@ -58,7 +56,7 @@ function Playing({ puzzle, clock, settings, onSettingsChange, onNewPuzzle }: Shi
                     puzzle={puzzle}
                     game={game}
                     elapsed={elapsed}
-                    onNewPuzzle={onNewPuzzle}
+                    onNewPuzzle={() => onNewPuzzle()}
                 />
                 <BoardStatus puzzle={puzzle} game={game} elapsed={elapsed} />
             </main>

--- a/shikaku/react/src/game/game.tsx
+++ b/shikaku/react/src/game/game.tsx
@@ -11,7 +11,7 @@
 import { useMemo } from 'react';
 import { Diagram, type InteractionsOptions } from '@joint/react-plus';
 import { Board } from '@/canvas/board';
-import { buildSquares } from '@/canvas/cells';
+import { buildBoard } from '@/canvas/cells';
 import { Toolbar, type Settings } from '@/toolbar/toolbar';
 import type { Puzzle } from '@/puzzle/types';
 import { BoardStatus } from './board-status';
@@ -32,11 +32,13 @@ export interface ShikakuGameProps {
     readonly puzzle: Puzzle;
     /** `false` freezes the timer at zero, for a reproducible screenshot. */
     readonly clock: boolean;
+    /** What this board was built with — settings can differ before New puzzle. */
+    readonly fillOnes: boolean;
     readonly settings: Settings;
     readonly onNewPuzzle: (settings?: Settings) => void;
 }
 
-function Playing({ puzzle, clock, settings, onNewPuzzle }: ShikakuGameProps) {
+function Playing({ puzzle, clock, fillOnes, settings, onNewPuzzle }: ShikakuGameProps) {
     const game = useGame(puzzle);
     // Stops the moment the last square is covered, so the toast can report the
     // time the board actually took — and never starts at all when the clock has
@@ -47,6 +49,7 @@ function Playing({ puzzle, clock, settings, onNewPuzzle }: ShikakuGameProps) {
         <>
             <Toolbar
                 puzzle={puzzle}
+                fillOnes={fillOnes}
                 game={game}
                 settings={settings}
                 onNewPuzzle={onNewPuzzle}
@@ -65,12 +68,15 @@ function Playing({ puzzle, clock, settings, onNewPuzzle }: ShikakuGameProps) {
 }
 
 export function ShikakuGame(props: ShikakuGameProps) {
-    const squares = useMemo(() => buildSquares(props.puzzle), [props.puzzle]);
+    const cells = useMemo(
+        () => buildBoard(props.puzzle, props.fillOnes),
+        [props.puzzle, props.fillOnes]
+    );
 
     return (
         // `history` is what gives the demo undo and redo, buttons and keyboard
         // shortcuts alike.
-        <Diagram initialCells={squares} interactions={INTERACTIONS} history>
+        <Diagram initialCells={cells} interactions={INTERACTIONS} history>
             <Playing {...props} />
         </Diagram>
     );

--- a/shikaku/react/src/game/use-game.ts
+++ b/shikaku/react/src/game/use-game.ts
@@ -22,7 +22,10 @@ import { coveredCells } from '@/puzzle/rules';
 import type { Puzzle, Rect, Region } from '@/puzzle/types';
 
 export interface GameApi {
+    /** Every rectangle on the board, the given ones included. */
     readonly regions: readonly Region[];
+    /** Only the ones the player placed. */
+    readonly placed: readonly Region[];
     /** Add a rectangle that has already been validated. */
     readonly place: (rect: Rect, clueIndex: number) => void;
     /** Drop a rectangle by id — which is its element id. */
@@ -55,6 +58,7 @@ function selectRegions(cells: readonly { id?: unknown; data?: unknown }[]): read
             rect: data.rect,
             clueIndex: data.clueIndex,
             color: data.color,
+            given: data.given,
         });
     }
     return regions;
@@ -75,6 +79,7 @@ function sameRegions(a: readonly Region[], b: readonly Region[]): boolean {
         return (
             region.id === other.id &&
             region.color === other.color &&
+            region.given === other.given &&
             region.clueIndex === other.clueIndex &&
             region.rect.w === other.rect.w &&
             region.rect.h === other.rect.h
@@ -105,6 +110,9 @@ export function useGame(puzzle: Puzzle): GameApi {
         [puzzle, regions, setCell]
     );
 
+    /** What the player has placed — the board's own 1s are not theirs to move. */
+    const placed = useMemo(() => regions.filter((region) => !region.given), [regions]);
+
     const remove = useCallback(
         (id: string) => {
             removeCells([id]);
@@ -113,10 +121,10 @@ export function useGame(puzzle: Puzzle): GameApi {
     );
 
     const clear = useCallback(() => {
-        if (regions.length === 0) return;
+        if (placed.length === 0) return;
         // One transaction, so clearing a full board is one press of undo away.
-        transaction(() => removeCells(regions.map((region) => region.id)));
-    }, [regions, removeCells, transaction]);
+        transaction(() => removeCells(placed.map((region) => region.id)));
+    }, [placed, removeCells, transaction]);
 
     const covered = useMemo(() => coveredCells(regions), [regions]);
     const total = puzzle.cols * puzzle.rows;
@@ -128,6 +136,7 @@ export function useGame(puzzle: Puzzle): GameApi {
         undo,
         redo,
         clear,
+        placed,
         canUndo,
         canRedo,
         covered,

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -240,9 +240,9 @@ button.icon.copied {
     border-color: var(--solved-color);
 }
 
-/* Help ------------------------------------------------------------------- */
+/* Dialogs ---------------------------------------------------------------- */
 
-.help {
+.dialog {
     max-width: 520px;
     padding: 22px 24px;
     color: var(--text-color);
@@ -252,16 +252,16 @@ button.icon.copied {
     box-shadow: 0 20px 60px rgb(50 42 73 / 24%);
 }
 
-.help::backdrop {
+.dialog::backdrop {
     background: rgb(50 42 73 / 32%);
 }
 
-.help h2 {
+.dialog h2 {
     margin: 0 0 8px;
     font-size: 18px;
 }
 
-.help h3 {
+.dialog h3 {
     margin: 20px 0 8px;
     font-size: 13px;
     font-weight: 700;
@@ -270,27 +270,27 @@ button.icon.copied {
     color: var(--muted-color);
 }
 
-.help p,
-.help li {
+.dialog p,
+.dialog li {
     font-size: 14px;
     line-height: 1.5;
 }
 
-.help p {
+.dialog p {
     margin: 0;
 }
 
-.help ul {
+.dialog ul {
     margin: 0;
     padding-left: 18px;
 }
 
-.help li + li {
+.dialog li + li {
     margin-top: 6px;
 }
 
-.help code,
-.help kbd {
+.dialog code,
+.dialog kbd {
     padding: 1px 5px;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 12px;
@@ -299,10 +299,48 @@ button.icon.copied {
     border-radius: 4px;
 }
 
-.help form {
+.dialog-actions {
     display: flex;
     justify-content: flex-end;
+    gap: 8px;
     margin-top: 22px;
+}
+
+.dialog-fields {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 24px;
+    margin-top: 16px;
+}
+
+/*
+ * Two buttons that read as one: the whole thing generates a board, and its
+ * right-hand end says there is a choice behind it.
+ */
+.split {
+    display: flex;
+}
+
+.split > button:first-child {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.split-more {
+    display: grid;
+    place-items: center;
+    width: 26px;
+    padding: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    /* A hairline between the halves, in the button's own foreground color. */
+    box-shadow: inset 1px 0 0 rgb(255 255 255 / 35%);
+}
+
+.split-more svg {
+    display: block;
+    width: 15px;
+    height: 15px;
 }
 
 /* Board ------------------------------------------------------------------ */

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -37,6 +37,13 @@
     --region-fill-7: #f8d2bc;
     --region-stroke-7: #dc6b36;
 
+    /*
+     * The board's own 1s. Gray on purpose: they are not one of the player's
+     * rectangles, and nothing about them is a choice.
+     */
+    --given-fill: #dfe5e9;
+    --given-stroke: #9aa6b0;
+
     /* Shown while a drag would produce a rectangle that cannot be placed. */
     --reject-fill: #f6c4c4;
     --reject-stroke: #d63b3b;
@@ -86,6 +93,9 @@
     --region-stroke-6: #58b0e0;
     --region-fill-7: #57301f;
     --region-stroke-7: #ef8a5c;
+
+    --given-fill: #2b313c;
+    --given-stroke: #5b6675;
 
     --reject-fill: #56222a;
     --reject-stroke: #ff6b6b;
@@ -437,6 +447,75 @@ button.icon.copied {
     display: block;
     width: 15px;
     height: 15px;
+}
+
+/*
+ * A checkbox drawn as a switch. The input keeps its place in the page rather
+ * than being display:none, so it stays focusable and keyboard-operable; the
+ * track and knob are drawn beside it and it is the label that is clicked.
+ */
+.switch {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+}
+
+.switch input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.switch-track {
+    position: relative;
+    flex: none;
+    width: 34px;
+    height: 20px;
+    background: var(--canvas-color);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.switch-track::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    background: var(--muted-color);
+    border-radius: 50%;
+    transition: transform 0.15s, background 0.15s;
+}
+
+.switch input:checked + .switch-track {
+    background: var(--main-color);
+    border-color: var(--main-color);
+}
+
+.switch input:checked + .switch-track::after {
+    background: #ffffff;
+    transform: translateX(14px);
+}
+
+.switch input:focus-visible + .switch-track {
+    outline: 2px solid var(--main-color);
+    outline-offset: 2px;
+}
+
+.switch-label {
+    display: grid;
+    font-size: 13px;
+    color: var(--text-color);
+}
+
+.switch-label small {
+    font-size: 12px;
+    color: var(--muted-color);
 }
 
 /* Board ------------------------------------------------------------------ */

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -164,27 +164,15 @@ body,
     letter-spacing: 0.01em;
 }
 
-.field {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 13px;
-    color: var(--muted-color);
-}
-
-.field input,
-.field select {
+.size-input {
     font: inherit;
     font-size: 13px;
+    width: 62px;
     color: var(--text-color);
     background: var(--surface-color);
     border: 1px solid var(--border-color);
     border-radius: 6px;
-    padding: 4px 6px;
-}
-
-.field input {
-    width: 52px;
+    padding: 5px 8px;
 }
 
 button {
@@ -306,11 +294,92 @@ button.icon.copied {
     margin-top: 22px;
 }
 
+/* One setting per row: a label, and the controls under it. */
 .dialog-fields {
+    display: grid;
+    gap: 18px;
+    margin-top: 18px;
+}
+
+.field-row {
+    display: grid;
+    gap: 8px;
+    /* The difficulty row is a fieldset, which brings its own. */
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
+
+.field-label {
+    padding: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--muted-color);
+}
+
+.field-controls {
     display: flex;
-    flex-wrap: wrap;
-    gap: 12px 24px;
-    margin-top: 16px;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: var(--muted-color);
+}
+
+/*
+ * The difficulty choices: three radios drawn as one segmented control. The
+ * inputs stay in the page rather than being display:none, so they keep their
+ * focus ring and their keyboard behavior.
+ */
+.choices {
+    display: flex;
+}
+
+.choice input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.choice span {
+    display: block;
+    padding: 6px 14px;
+    font-size: 13px;
+    color: var(--text-color);
+    background: var(--surface-color);
+    border: 1px solid var(--border-color);
+    cursor: pointer;
+    text-transform: capitalize;
+}
+
+.choice:first-child span {
+    border-radius: 6px 0 0 6px;
+}
+
+.choice:last-child span {
+    border-radius: 0 6px 6px 0;
+}
+
+/* One border between neighbors rather than two. */
+.choice + .choice span {
+    margin-left: -1px;
+}
+
+.choice span:hover {
+    color: var(--main-color);
+}
+
+.choice input:checked + span {
+    position: relative;
+    color: #ffffff;
+    background: var(--main-color);
+    border-color: var(--main-color);
+}
+
+.choice input:focus-visible + span {
+    outline: 2px solid var(--main-color);
+    outline-offset: 2px;
 }
 
 /*

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -541,7 +541,10 @@ button.icon.copied {
     background: var(--canvas-color);
 }
 
-/* The squares never move, so the pointer should say "draw", not "drag". */
+/*
+ * The squares never move, so the pointer says "draw", not "drag". The
+ * rectangles drawn over them say something else — see `render-cell.tsx`.
+ */
 .board-paper .joint-cell {
     cursor: crosshair;
 }

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -338,12 +338,23 @@ button.icon.copied {
 }
 
 /*
- * The difficulty choices: three radios drawn as one segmented control. The
- * inputs stay in the page rather than being display:none, so they keep their
- * focus ring and their keyboard behavior.
+ * The difficulty choices: three radios drawn as one segmented control.
+ *
+ * A recessed track with the chosen one raised out of it, rather than a filled
+ * segment. Filling it needs a strong color, and the two strong colors available
+ * both say the wrong thing — the accent belongs to Generate, and near-black is
+ * heavier than a three-way choice deserves. Depth carries it instead.
+ *
+ * The inputs stay in the page rather than being display:none, so they keep
+ * their focus ring and their keyboard behavior.
  */
 .choices {
-    display: flex;
+    display: inline-flex;
+    gap: 2px;
+    padding: 3px;
+    background: var(--canvas-color);
+    border: 1px solid var(--border-color);
+    border-radius: 9px;
 }
 
 .choice input {
@@ -356,47 +367,23 @@ button.icon.copied {
 
 .choice span {
     display: block;
-    padding: 6px 14px;
+    padding: 5px 14px;
     font-size: 13px;
-    color: var(--text-color);
-    background: var(--surface-color);
-    border: 1px solid var(--border-color);
+    color: var(--muted-color);
+    border-radius: 6px;
     cursor: pointer;
     text-transform: capitalize;
 }
 
-.choice:first-child span {
-    border-radius: 6px 0 0 6px;
-}
-
-.choice:last-child span {
-    border-radius: 0 6px 6px 0;
-}
-
-/* One border between neighbors rather than two. */
-.choice + .choice span {
-    margin-left: -1px;
-}
-
 .choice span:hover {
     color: var(--text-color);
-    border-color: var(--muted-color);
 }
 
-/*
- * Neutral rather than the accent: the accent belongs to Generate, the one
- * thing in the dialog you press to make something happen. A chosen segment
- * wearing the same color competes with it — it looks like a second button
- * rather than the answer to a question.
- *
- * Inverting the text color reads as "chosen" in both themes: a dark chip on
- * the light one, a light chip on the dark one.
- */
 .choice input:checked + span {
-    position: relative;
-    color: var(--surface-color);
-    background: var(--text-color);
-    border-color: var(--text-color);
+    color: var(--text-color);
+    font-weight: 600;
+    background: var(--surface-color);
+    box-shadow: 0 1px 2px rgb(0 0 0 / 12%);
 }
 
 .choice input:focus-visible + span {

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -186,9 +186,14 @@ button {
     cursor: pointer;
 }
 
+/*
+ * Hover darkens rather than turning blue. The accent means "this is the action
+ * here" — Generate, New puzzle — and a row of icons that all go blue under the
+ * pointer spends it on nothing.
+ */
 button:hover:not(:disabled) {
-    border-color: var(--main-color);
-    color: var(--main-color);
+    color: var(--text-color);
+    border-color: var(--muted-color);
 }
 
 button:disabled {
@@ -374,14 +379,24 @@ button.icon.copied {
 }
 
 .choice span:hover {
-    color: var(--main-color);
+    color: var(--text-color);
+    border-color: var(--muted-color);
 }
 
+/*
+ * Neutral rather than the accent: the accent belongs to Generate, the one
+ * thing in the dialog you press to make something happen. A chosen segment
+ * wearing the same color competes with it — it looks like a second button
+ * rather than the answer to a question.
+ *
+ * Inverting the text color reads as "chosen" in both themes: a dark chip on
+ * the light one, a light chip on the dark one.
+ */
 .choice input:checked + span {
     position: relative;
-    color: #ffffff;
-    background: var(--main-color);
-    border-color: var(--main-color);
+    color: var(--surface-color);
+    background: var(--text-color);
+    border-color: var(--text-color);
 }
 
 .choice input:focus-visible + span {

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -291,7 +291,9 @@ button.icon.copied {
     display: flex;
     justify-content: flex-end;
     gap: 8px;
-    margin-top: 22px;
+    /* Further than the gap between the settings: these are a different kind of
+       thing, not another row of the form. */
+    margin-top: 28px;
 }
 
 /* One setting per row: a label, and the controls under it. */
@@ -302,15 +304,20 @@ button.icon.copied {
 }
 
 .field-row {
-    display: grid;
-    gap: 8px;
-    /* The difficulty row is a fieldset, which brings its own. */
+    /*
+     * Block rather than grid: the difficulty row is a fieldset and its label is
+     * a <legend>, which browsers lay out in the fieldset's border box rather
+     * than as a child — a grid `gap` never reaches it, and the label ended up
+     * flush against the buttons. The label carries the spacing itself instead.
+     */
     margin: 0;
     padding: 0;
     border: 0;
 }
 
 .field-label {
+    display: block;
+    margin-bottom: 8px;
     padding: 0;
     font-size: 13px;
     font-weight: 600;

--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -375,6 +375,24 @@ button.icon.copied {
     text-transform: capitalize;
 }
 
+/*
+ * Every segment is sized for its own word *in bold*, whether or not it is the
+ * chosen one. The selected segment is semibold, and bold text is wider — so
+ * without this the track, and the dialog around it, changed width every time
+ * the selection moved.
+ *
+ * A zero-height copy of the word does it: it contributes its width and nothing
+ * else.
+ */
+.choice span::after {
+    content: attr(data-label);
+    display: block;
+    height: 0;
+    overflow: hidden;
+    font-weight: 600;
+    pointer-events: none;
+}
+
 .choice span:hover {
     color: var(--text-color);
 }

--- a/shikaku/react/src/puzzle/colors.test.ts
+++ b/shikaku/react/src/puzzle/colors.test.ts
@@ -3,7 +3,7 @@ import { PALETTE_SIZE, pickColor } from './colors';
 import type { Region } from './types';
 
 function region(id: string, x: number, y: number, w: number, h: number, color: number): Region {
-    return { id, rect: { x, y, w, h }, clueIndex: 0, color };
+    return { id, rect: { x, y, w, h }, clueIndex: 0, color, given: false };
 }
 
 describe('pickColor', () => {

--- a/shikaku/react/src/puzzle/generate.test.ts
+++ b/shikaku/react/src/puzzle/generate.test.ts
@@ -75,6 +75,27 @@ describe('generatePuzzle', () => {
         for (const puzzle of boards()) expect(puzzle.unique).toBe(true);
     });
 
+    it('never leaves two single cells touching', () => {
+        // A 1 is the one clue with no decision in it, so a run of them is dead
+        // space — and two 1s side by side are always a 1x2 the cutting happened
+        // not to make.
+        for (const puzzle of boards()) {
+            const singles = new Set(
+                puzzle.solution.filter((r) => r.w === 1 && r.h === 1).map((r) => `${r.x}:${r.y}`)
+            );
+            for (const key of singles) {
+                const [x, y] = key.split(':').map(Number);
+                const neighbors = [
+                    `${x - 1}:${y}`,
+                    `${x + 1}:${y}`,
+                    `${x}:${y - 1}`,
+                    `${x}:${y + 1}`,
+                ];
+                expect(neighbors.filter((n) => singles.has(n))).toEqual([]);
+            }
+        }
+    });
+
     it('is a pure function of its seed', () => {
         const options = { cols: 9, rows: 7, seed: 314159, difficulty: 'hard' as const };
         expect(generatePuzzle(options)).toEqual(generatePuzzle(options));

--- a/shikaku/react/src/puzzle/generate.ts
+++ b/shikaku/react/src/puzzle/generate.ts
@@ -124,6 +124,56 @@ function partition(cols: number, rows: number, maxArea: number, rng: Rng): Rect[
     return rects;
 }
 
+/**
+ * Merges runs of single cells into one rectangle each.
+ *
+ * Two 1s side by side are legal — each is its own rectangle — but they are
+ * always a 1x2 that the cutting happened not to make, and a run of them is dead
+ * space: a 1 is the one clue with no decision in it, so three of them in a row
+ * is three squares the player is given for nothing.
+ *
+ * Rows first, then columns over what is left. A cell taken into a horizontal
+ * run is no longer single, so the column pass cannot re-merge it — which is
+ * what keeps every merge a rectangle rather than an L. After both passes no
+ * two single cells touch.
+ */
+function mergeSingleRuns(rects: readonly Rect[], cols: number, rows: number): Rect[] {
+    const merged: Rect[] = [];
+    const singles = new Map<string, Rect>();
+    for (const rect of rects) {
+        if (rect.w === 1 && rect.h === 1) singles.set(`${rect.x}:${rect.y}`, rect);
+        else merged.push(rect);
+    }
+
+    const take = (x: number, y: number): boolean => singles.delete(`${x}:${y}`);
+
+    // Horizontal runs.
+    for (let y = 0; y < rows; y++) {
+        for (let x = 0; x < cols; x++) {
+            if (!singles.has(`${x}:${y}`)) continue;
+            let length = 0;
+            while (take(x + length, y)) length++;
+            merged.push({ x, y, w: length, h: 1 });
+        }
+    }
+
+    // Vertical runs, over the cells no horizontal run claimed. A run of one is
+    // just the single cell again.
+    const leftovers = merged.filter((rect) => rect.w === 1 && rect.h === 1);
+    for (const rect of leftovers) singles.set(`${rect.x}:${rect.y}`, rect);
+    const kept = merged.filter((rect) => rect.w !== 1 || rect.h !== 1);
+
+    for (let x = 0; x < cols; x++) {
+        for (let y = 0; y < rows; y++) {
+            if (!singles.has(`${x}:${y}`)) continue;
+            let length = 0;
+            while (take(x, y + length)) length++;
+            kept.push({ x, y, w: 1, h: length });
+        }
+    }
+    return kept;
+}
+
 /** Puts each rectangle's number on a random cell inside it. */
 function placeClues(rects: readonly Rect[], rng: Rng): Clue[] {
     return rects.map((rect) => ({
@@ -160,7 +210,7 @@ export function generatePuzzle({ cols, rows, seed, difficulty }: GenerateOptions
     for (let i = 0; i < MAX_ATTEMPTS; i++) {
         const attemptSeed = (seed + i) >>> 0;
         const rng = mulberry32(attemptSeed);
-        const solution = partition(cols, rows, maxArea, rng);
+        const solution = mergeSingleRuns(partition(cols, rows, maxArea, rng), cols, rows);
         const clues = placeClues(solution, rng);
         const solutions = countSolutions({ cols, rows, clues }, 2);
         const unique = solutions === 1;

--- a/shikaku/react/src/puzzle/rules.test.ts
+++ b/shikaku/react/src/puzzle/rules.test.ts
@@ -7,7 +7,9 @@ const CLUES: Clue[] = [
     { x: 3, y: 0, value: 2 },
 ];
 
-const PLACED: Region[] = [{ id: 'r0', rect: { x: 0, y: 0, w: 2, h: 2 }, clueIndex: 0, color: 0 }];
+const PLACED: Region[] = [
+    { id: 'r0', rect: { x: 0, y: 0, w: 2, h: 2 }, clueIndex: 0, color: 0, given: false },
+];
 
 describe('validatePlacement', () => {
     it('accepts a rectangle whose area matches its one number', () => {

--- a/shikaku/react/src/puzzle/types.ts
+++ b/shikaku/react/src/puzzle/types.ts
@@ -48,8 +48,10 @@ export interface Region {
     readonly rect: Rect;
     /** Index into `Puzzle.clues` of the clue this rectangle claims. */
     readonly clueIndex: number;
-    /** Index into the palette in `colors.ts`. */
+    /** Index into the palette in `colors.ts`. `-1` for a given, which is gray. */
     readonly color: number;
+    /** True for a rectangle the board came with — its 1s. */
+    readonly given: boolean;
 }
 
 /** Every cell of `rect`, row by row. */

--- a/shikaku/react/src/toolbar/help-dialog.tsx
+++ b/shikaku/react/src/toolbar/help-dialog.tsx
@@ -72,6 +72,12 @@ export function HelpDialog({ open, onClose }: HelpDialogProps) {
                     between two of them is always readable.
                 </li>
                 <li>
+                    A board starts with its <code>1</code>s filled in — a 1 has only one
+                    rectangle it could ever be — drawn gray and without a number. Turn
+                    <b> Fill in the 1s</b> off in the New puzzle dialog to draw them
+                    yourself.
+                </li>
+                <li>
                     <b>New puzzle</b> generates one at the current size; the arrow beside
                     it opens the size and difficulty. Difficulty is the largest rectangle
                     the generator may cut.

--- a/shikaku/react/src/toolbar/help-dialog.tsx
+++ b/shikaku/react/src/toolbar/help-dialog.tsx
@@ -28,7 +28,7 @@ export function HelpDialog({ open, onClose }: HelpDialogProps) {
     return (
         // `close` covers every way the platform can shut it — Escape, the
         // backdrop, the form button — so React state never drifts from the DOM.
-        <dialog ref={dialog} className="help" onClose={onClose}>
+        <dialog ref={dialog} className="dialog" onClose={onClose}>
             <h2>Shikaku</h2>
             <p>
                 Cut the whole grid into rectangles. Every rectangle must contain
@@ -72,8 +72,9 @@ export function HelpDialog({ open, onClose }: HelpDialogProps) {
                     between two of them is always readable.
                 </li>
                 <li>
-                    <b>Size</b> and <b>Difficulty</b> take effect on <b>New puzzle</b>.
-                    Difficulty is the largest rectangle the generator may cut.
+                    <b>New puzzle</b> generates one at the current size; the arrow beside
+                    it opens the size and difficulty. Difficulty is the largest rectangle
+                    the generator may cut.
                 </li>
                 <li>
                     The clock in the corner starts with the board and stops when you
@@ -86,7 +87,7 @@ export function HelpDialog({ open, onClose }: HelpDialogProps) {
                 </li>
             </ul>
 
-            <form method="dialog">
+            <form method="dialog" className="dialog-actions">
                 <button type="submit" className="primary">
                     Got it
                 </button>

--- a/shikaku/react/src/toolbar/icons.tsx
+++ b/shikaku/react/src/toolbar/icons.tsx
@@ -97,6 +97,15 @@ export function CheckIcon() {
     );
 }
 
+/** A chevron pointing down: there is more behind this button. */
+export function ChevronDownIcon() {
+    return (
+        <Icon>
+            <path d="m6 9 6 6 6-6" />
+        </Icon>
+    );
+}
+
 /** A question mark in a circle. */
 export function HelpIcon() {
     return (

--- a/shikaku/react/src/toolbar/settings-dialog.tsx
+++ b/shikaku/react/src/toolbar/settings-dialog.tsx
@@ -105,6 +105,24 @@ export function SettingsDialog({ open, settings, onClose, onNewPuzzle }: Setting
                         ))}
                     </div>
                 </fieldset>
+
+                <label className="switch">
+                    <input
+                        type="checkbox"
+                        checked={draft.fillOnes}
+                        onChange={(event) =>
+                            setDraft((previous) => ({
+                                ...previous,
+                                fillOnes: event.target.checked,
+                            }))
+                        }
+                    />
+                    <span className="switch-track" aria-hidden="true" />
+                    <span className="switch-label">
+                        Fill in the 1s
+                        <small>A 1 has only one rectangle it could ever be</small>
+                    </span>
+                </label>
             </div>
 
             <form method="dialog" className="dialog-actions">

--- a/shikaku/react/src/toolbar/settings-dialog.tsx
+++ b/shikaku/react/src/toolbar/settings-dialog.tsx
@@ -95,7 +95,12 @@ export function SettingsDialog({ open, settings, onClose, onNewPuzzle }: Setting
                                         setDraft((previous) => ({ ...previous, difficulty }))
                                     }
                                 />
-                                <span>{difficulty}</span>
+                                {/*
+                                  * `data-label` feeds a hidden bold copy of the
+                                  * word, which is what keeps the segment as wide
+                                  * as its own selected state — see `index.css`.
+                                  */}
+                                <span data-label={difficulty}>{difficulty}</span>
                             </label>
                         ))}
                     </div>

--- a/shikaku/react/src/toolbar/settings-dialog.tsx
+++ b/shikaku/react/src/toolbar/settings-dialog.tsx
@@ -1,0 +1,102 @@
+/**
+ * What the next board should be.
+ *
+ * Size and difficulty are here rather than in the toolbar because they are not
+ * controls for the board on screen — they describe the next one. Out of the row
+ * they also stop the toolbar wrapping on anything narrow.
+ *
+ * The dialog edits a draft and hands it over only when *New puzzle* is pressed,
+ * so closing it leaves the board and the settings exactly as they were. That
+ * also means the size fields never need to be reconciled with a board mid-edit.
+ */
+import { useEffect, useRef, useState } from 'react';
+import type { Difficulty } from '@/puzzle/types';
+import { SizeInput } from './size-input';
+import type { Settings } from './toolbar';
+
+const DIFFICULTIES: readonly Difficulty[] = ['easy', 'medium', 'hard'];
+
+export interface SettingsDialogProps {
+    readonly open: boolean;
+    readonly settings: Settings;
+    readonly onClose: () => void;
+    /** Generate a board from these settings. */
+    readonly onNewPuzzle: (settings: Settings) => void;
+}
+
+export function SettingsDialog({ open, settings, onClose, onNewPuzzle }: SettingsDialogProps) {
+    const dialog = useRef<HTMLDialogElement>(null);
+    const [draft, setDraft] = useState(settings);
+
+    useEffect(() => {
+        const element = dialog.current;
+        if (!element) return;
+        if (open && !element.open) {
+            // Opened, so it starts from what the board on screen was made with.
+            setDraft(settings);
+            element.showModal();
+        }
+        if (!open && element.open) element.close();
+    }, [open, settings]);
+
+    return (
+        <dialog ref={dialog} className="dialog" onClose={onClose}>
+            <h2>New puzzle</h2>
+
+            <div className="dialog-fields">
+                <label className="field">
+                    <span>Size</span>
+                    <SizeInput
+                        label="Board width"
+                        value={draft.cols}
+                        onChange={(cols) => setDraft((previous) => ({ ...previous, cols }))}
+                    />
+                    <span aria-hidden="true">×</span>
+                    <SizeInput
+                        label="Board height"
+                        value={draft.rows}
+                        onChange={(rows) => setDraft((previous) => ({ ...previous, rows }))}
+                    />
+                </label>
+
+                <label
+                    className="field"
+                    title="The largest rectangle the generator may cut, scaled to the board"
+                >
+                    <span>Difficulty</span>
+                    <select
+                        value={draft.difficulty}
+                        onChange={(event) =>
+                            setDraft((previous) => ({
+                                ...previous,
+                                difficulty: event.target.value as Difficulty,
+                            }))
+                        }
+                    >
+                        {DIFFICULTIES.map((difficulty) => (
+                            <option key={difficulty} value={difficulty}>
+                                {difficulty}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+            </div>
+
+            <form method="dialog" className="dialog-actions">
+                <button type="submit">Cancel</button>
+                {/*
+                  * `formMethod="dialog"` so this closes the dialog too; the
+                  * click handler is what generates the board.
+                  */}
+                <button
+                    type="submit"
+                    className="primary"
+                    formMethod="dialog"
+                    onClick={() => onNewPuzzle(draft)}
+                >
+                    New puzzle
+                </button>
+            </form>
+        </dialog>
+    );
+}

--- a/shikaku/react/src/toolbar/settings-dialog.tsx
+++ b/shikaku/react/src/toolbar/settings-dialog.tsx
@@ -16,6 +16,12 @@ import type { Settings } from './toolbar';
 
 const DIFFICULTIES: readonly Difficulty[] = ['easy', 'medium', 'hard'];
 
+const DIFFICULTY_HINTS: Record<Difficulty, string> = {
+    easy: 'Small rectangles',
+    medium: 'A mix',
+    hard: 'Large rectangles, more places each number could sit',
+};
+
 export interface SettingsDialogProps {
     readonly open: boolean;
     readonly settings: Settings;
@@ -44,49 +50,64 @@ export function SettingsDialog({ open, settings, onClose, onNewPuzzle }: Setting
             <h2>New puzzle</h2>
 
             <div className="dialog-fields">
-                <label className="field">
-                    <span>Size</span>
-                    <SizeInput
-                        label="Board width"
-                        value={draft.cols}
-                        onChange={(cols) => setDraft((previous) => ({ ...previous, cols }))}
-                    />
-                    <span aria-hidden="true">×</span>
-                    <SizeInput
-                        label="Board height"
-                        value={draft.rows}
-                        onChange={(rows) => setDraft((previous) => ({ ...previous, rows }))}
-                    />
-                </label>
+                <div className="field-row">
+                    {/*
+                      * A span rather than a <label>: a label points at one
+                      * control and there are two here. Each input carries its
+                      * own accessible name.
+                      */}
+                    <span className="field-label">Size</span>
+                    <div className="field-controls">
+                        <SizeInput
+                            label="Board width"
+                            value={draft.cols}
+                            onChange={(cols) => setDraft((previous) => ({ ...previous, cols }))}
+                        />
+                        <span aria-hidden="true">×</span>
+                        <SizeInput
+                            label="Board height"
+                            value={draft.rows}
+                            onChange={(rows) => setDraft((previous) => ({ ...previous, rows }))}
+                        />
+                    </div>
+                </div>
 
-                <label
-                    className="field"
-                    title="The largest rectangle the generator may cut, scaled to the board"
-                >
-                    <span>Difficulty</span>
-                    <select
-                        value={draft.difficulty}
-                        onChange={(event) =>
-                            setDraft((previous) => ({
-                                ...previous,
-                                difficulty: event.target.value as Difficulty,
-                            }))
-                        }
-                    >
+                {/*
+                  * Three real radios behind the buttons: one choice out of
+                  * three, which is what a radio group is, and it arrows between
+                  * them from the keyboard without any work here.
+                  */}
+                <fieldset className="field-row">
+                    <legend className="field-label">Difficulty</legend>
+                    <div className="choices">
                         {DIFFICULTIES.map((difficulty) => (
-                            <option key={difficulty} value={difficulty}>
-                                {difficulty}
-                            </option>
+                            <label
+                                key={difficulty}
+                                className="choice"
+                                title={DIFFICULTY_HINTS[difficulty]}
+                            >
+                                <input
+                                    type="radio"
+                                    name="difficulty"
+                                    value={difficulty}
+                                    checked={draft.difficulty === difficulty}
+                                    onChange={() =>
+                                        setDraft((previous) => ({ ...previous, difficulty }))
+                                    }
+                                />
+                                <span>{difficulty}</span>
+                            </label>
                         ))}
-                    </select>
-                </label>
+                    </div>
+                </fieldset>
             </div>
 
             <form method="dialog" className="dialog-actions">
                 <button type="submit">Cancel</button>
                 {/*
-                  * `formMethod="dialog"` so this closes the dialog too; the
-                  * click handler is what generates the board.
+                  * "Generate" rather than "New puzzle" again: the dialog is
+                  * already titled that, and the button says what pressing it
+                  * does.
                   */}
                 <button
                     type="submit"
@@ -94,7 +115,7 @@ export function SettingsDialog({ open, settings, onClose, onNewPuzzle }: Setting
                     formMethod="dialog"
                     onClick={() => onNewPuzzle(draft)}
                 >
-                    New puzzle
+                    Generate
                 </button>
             </form>
         </dialog>

--- a/shikaku/react/src/toolbar/size-input.tsx
+++ b/shikaku/react/src/toolbar/size-input.tsx
@@ -46,6 +46,7 @@ export function SizeInput({ label, value, onChange }: SizeInputProps) {
     return (
         <input
             type="number"
+            className="size-input"
             aria-label={label}
             min={MIN_SIDE}
             max={MAX_SIDE}

--- a/shikaku/react/src/toolbar/toolbar.tsx
+++ b/shikaku/react/src/toolbar/toolbar.tsx
@@ -1,9 +1,9 @@
 /**
  * The controls.
  *
- * Size and difficulty are staged rather than applied: typing "1" on the way to
- * "12" should not throw away the board being played. They are read when *New
- * puzzle* is pressed, which is the button right next to them.
+ * Size and difficulty live in a dialog behind the *New puzzle* button rather
+ * than in the row: they describe the next board, not the one on screen, and out
+ * of the row the toolbar fits a phone without wrapping.
  */
 import { useEffect, useState } from 'react';
 import { boardUrl } from '@/board-request';
@@ -13,8 +13,18 @@ import type { Difficulty, Puzzle } from '@/puzzle/types';
 // URL — the built demo is served from a sub-path and a rooted one would 404.
 import jointjsLogo from '@/assets/jointjs-logo.svg';
 import { HelpDialog } from './help-dialog';
-import { CheckIcon, ClearIcon, HelpIcon, LinkIcon, MoonIcon, RedoIcon, SunIcon, UndoIcon } from './icons';
-import { SizeInput } from './size-input';
+import {
+    CheckIcon,
+    ChevronDownIcon,
+    ClearIcon,
+    HelpIcon,
+    LinkIcon,
+    MoonIcon,
+    RedoIcon,
+    SunIcon,
+    UndoIcon,
+} from './icons';
+import { SettingsDialog } from './settings-dialog';
 import { useTheme } from './use-theme';
 
 export interface Settings {
@@ -22,8 +32,6 @@ export interface Settings {
     readonly rows: number;
     readonly difficulty: Difficulty;
 }
-
-const DIFFICULTIES: readonly Difficulty[] = ['easy', 'medium', 'hard'];
 
 /*
  * Shortcut labels for the button tooltips. The bindings themselves are the
@@ -48,12 +56,13 @@ export interface ToolbarProps {
     readonly puzzle: Puzzle;
     readonly game: GameApi;
     readonly settings: Settings;
-    readonly onSettingsChange: (settings: Settings) => void;
-    readonly onNewPuzzle: () => void;
+    /** Generate a board — from `settings`, or from the ones given. */
+    readonly onNewPuzzle: (settings?: Settings) => void;
 }
 
-export function Toolbar({ puzzle, game, settings, onSettingsChange, onNewPuzzle }: ToolbarProps) {
+export function Toolbar({ puzzle, game, settings, onNewPuzzle }: ToolbarProps) {
     const [helpOpen, setHelpOpen] = useState(false);
+    const [settingsOpen, setSettingsOpen] = useState(false);
     const [shared, setShared] = useState<Shared>('idle');
     const { theme, toggleTheme } = useTheme();
 
@@ -95,49 +104,38 @@ export function Toolbar({ puzzle, game, settings, onSettingsChange, onNewPuzzle 
             </div>
 
             <div className="toolbar-group">
-                <label className="field">
-                    <span>Size</span>
-                    <SizeInput
-                        label="Board width"
-                        value={settings.cols}
-                        onChange={(cols) => onSettingsChange({ ...settings, cols })}
-                    />
-                    <span aria-hidden="true">×</span>
-                    <SizeInput
-                        label="Board height"
-                        value={settings.rows}
-                        onChange={(rows) => onSettingsChange({ ...settings, rows })}
-                    />
-                </label>
-                <label
-                    className="field"
-                    title="The largest rectangle the generator may cut, scaled to the board"
-                >
-                    <span>Difficulty</span>
-                    <select
-                        value={settings.difficulty}
-                        onChange={(event) =>
-                            onSettingsChange({
-                                ...settings,
-                                difficulty: event.target.value as Difficulty,
-                            })
-                        }
+                {/*
+                  * A split button: the left half generates a board from the
+                  * settings as they stand, the right half opens the dialog that
+                  * holds them. The common case is one press.
+                  */}
+                <div className="split">
+                    <button
+                        type="button"
+                        className="primary"
+                        title="Generate a board at the chosen size and difficulty"
+                        onClick={() => onNewPuzzle()}
                     >
-                        {DIFFICULTIES.map((difficulty) => (
-                            <option key={difficulty} value={difficulty}>
-                                {difficulty}
-                            </option>
-                        ))}
-                    </select>
-                </label>
-                <button
-                    type="button"
-                    className="primary"
-                    title="Generate a board at the chosen size and difficulty"
-                    onClick={onNewPuzzle}
-                >
-                    New puzzle
-                </button>
+                        New puzzle
+                    </button>
+                    <button
+                        type="button"
+                        className="primary split-more"
+                        title="Size and difficulty"
+                        aria-label="Size and difficulty"
+                        aria-haspopup="dialog"
+                        aria-expanded={settingsOpen}
+                        onClick={() => setSettingsOpen(true)}
+                    >
+                        <ChevronDownIcon />
+                    </button>
+                </div>
+                <SettingsDialog
+                    open={settingsOpen}
+                    settings={settings}
+                    onClose={() => setSettingsOpen(false)}
+                    onNewPuzzle={onNewPuzzle}
+                />
             </div>
 
             <div className="toolbar-group">

--- a/shikaku/react/src/toolbar/toolbar.tsx
+++ b/shikaku/react/src/toolbar/toolbar.tsx
@@ -31,6 +31,14 @@ export interface Settings {
     readonly cols: number;
     readonly rows: number;
     readonly difficulty: Difficulty;
+    /**
+     * Start with the 1s already placed.
+     *
+     * A clue of 1 has exactly one rectangle it could ever be, so filling them
+     * in takes nothing away from the puzzle — but it is a smaller board to
+     * solve, and some people would rather have the whole of it.
+     */
+    readonly fillOnes: boolean;
 }
 
 /*
@@ -54,13 +62,15 @@ const SHARE_TITLES: Record<Shared, string> = {
 
 export interface ToolbarProps {
     readonly puzzle: Puzzle;
+    /** What the board on screen was built with, for the share link. */
+    readonly fillOnes: boolean;
     readonly game: GameApi;
     readonly settings: Settings;
     /** Generate a board — from `settings`, or from the ones given. */
     readonly onNewPuzzle: (settings?: Settings) => void;
 }
 
-export function Toolbar({ puzzle, game, settings, onNewPuzzle }: ToolbarProps) {
+export function Toolbar({ puzzle, fillOnes, game, settings, onNewPuzzle }: ToolbarProps) {
     const [helpOpen, setHelpOpen] = useState(false);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const [shared, setShared] = useState<Shared>('idle');
@@ -80,7 +90,9 @@ export function Toolbar({ puzzle, game, settings, onNewPuzzle }: ToolbarProps) {
      */
     const share = async() => {
         try {
-            await navigator.clipboard.writeText(boardUrl(puzzle, window.location.href));
+            await navigator.clipboard.writeText(
+                boardUrl({ ...puzzle, fillOnes }, window.location.href)
+            );
             setShared('copied');
         } catch {
             // No clipboard: an insecure origin, or permission refused. Saying so
@@ -163,7 +175,7 @@ export function Toolbar({ puzzle, game, settings, onNewPuzzle }: ToolbarProps) {
                     type="button"
                     className="icon"
                     onClick={game.clear}
-                    disabled={game.regions.length === 0}
+                    disabled={game.placed.length === 0}
                     title="Clear the board"
                     aria-label="Clear the board"
                 >


### PR DESCRIPTION
Follows #52.

## Size and difficulty move into a dialog

They describe the *next* board, not the one on screen, so they were taking up
the middle of the toolbar for something set rarely. **New puzzle** is a split
button now: the left half generates at the current size, the arrow beside it
opens a dialog holding the settings. On a phone that takes the toolbar from
three rows to two.

- **Difficulty is a segmented control**, not a select — one choice out of three
  is a radio group, so it is three real radios behind the buttons, arrowing
  between themselves from the keyboard with their focus ring intact.
- Drawn as a **recessed track with the chosen one raised out of it**. Filling a
  segment needs a strong color and both on hand say the wrong thing: the accent
  belongs to Generate, near-black outweighs a three-way choice. Depth carries it.
- The primary button says **Generate** — the dialog is already titled *New
  puzzle*.
- It edits a **draft**: Cancel leaves the board and the settings alone, and
  reopening starts from what the board on screen was made with.

## Boards start with their 1s filled in

A clue of `1` has exactly one rectangle it could ever be, so there is no
decision in it. Those are now placed for you — gray, no number, not removable.

They are seeded into `initialCells` rather than placed, which keeps them off the
undo stack for free: `<Diagram history>` records what happens after the graph is
built, not what it was built with. Otherwise they are ordinary rectangles: they
block an overlapping drag, they count toward the squares covered, and **Clear**
works on what the player placed, so a cleared board returns to its givens.

Off with the toggle in the dialog, or `?ones=off` / `VITE_ONES=off`. The share
link carries it, and only when it is off, so an ordinary link stays short.

**The generator no longer leaves 1s side by side.** The partition falls back to
a single cell when nothing larger fits the hole left behind, and those sometimes
landed next to each other — legal, but two adjacent 1×1s are always a 1×2 the
cutting happened not to make. A merge pass folds runs of single cells into one
rectangle: rows first, then columns over what is left, which is what keeps every
merge a rectangle rather than an L.

Over 40 boards each at 10×10, the share of 1s touching another went 9% / 16% /
18% (easy / medium / hard) to **zero**. Still an exact partition, still uniquely
solvable, generation as fast as before.

## Fixes found while building it

- **The dialog changed size when the difficulty changed** — the chosen segment
  is semibold and bold text is wider, so it measured 253.41 / 254.13 / 253.50 px
  for easy / medium / hard. Every segment is sized for its own word in bold now;
  all three give `257.03 × 269`.
- **The difficulty label sat flush against its buttons** — the row was a grid,
  and a `<legend>` is laid out in the fieldset's border box rather than as a
  child, so the gap never reached it.
- **The accent was spent on nothing** — every button turned blue on hover, so
  the one button that does something didn't stand out. Hover darkens instead.
- **The board gave away room at its sides** — 40 px all round became 14 px at
  the sides, where nothing lives. A 10×10 board on an iPhone 13 goes from 310 px
  across to 362.

37 tests, root lint and the production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)