### PR TITLE
fix: stop iOS zooming into the new-puzzle dialog

### DIFF
--- a/shikaku/react/src/index.css
+++ b/shikaku/react/src/index.css
@@ -185,6 +185,24 @@ body,
     padding: 5px 8px;
 }
 
+/*
+ * 16px on a touch screen, whatever it looks like elsewhere.
+ *
+ * iOS Safari zooms the page in when a field with smaller text takes focus, and
+ * it does not zoom back out when the field is done with — so opening this
+ * dialog, which focuses the first size input, left the board magnified with no
+ * way back but a pinch. Sixteen is the threshold; below it, Safari assumes the
+ * text is too small to type into.
+ *
+ * The alternative is `maximum-scale=1` on the viewport, which stops the zoom by
+ * taking pinch-zoom away from everyone. Not worth it.
+ */
+@media (pointer: coarse) {
+    .size-input {
+        font-size: 16px;
+    }
+}
+
 button {
     font: inherit;
     font-size: 13px;


### PR DESCRIPTION
Follows #53.

On a phone, opening the New puzzle dialog zoomed the page in, and Generate
never zoomed back out — only a pinch got it back.

**Why**: Safari zooms in when a field whose text is under 16px takes focus, and
does not restore the zoom when the field is done with. `showModal()` focuses the
first focusable element, which is the width input, at 13px.

**Fix**: the size fields are 16px on a coarse pointer — the threshold Safari
uses — and stay 13px everywhere else, so the dialog looks unchanged on a desktop.

```css
@media (pointer: coarse) {
    .size-input { font-size: 16px; }
}
```

The other way to stop it is `maximum-scale=1` on the viewport, which works by
taking pinch-zoom away from everyone. Not a trade worth making to save three
pixels of type.

## Verified

| | pointer: coarse | input font-size |
|---|---|---|
| iPhone 13 | true | **16px** |
| desktop | false | 13px |

The zoom itself I cannot reproduce here — it is Safari behavior, and Playwright
drives Chromium — so what is verified is that the condition causing it is gone.

## One thing I noticed and did not change

`showModal()` focuses the width input, so on a phone the keyboard may open just
from opening the dialog. Moving `autofocus` to **Cancel** would stop that, and
Cancel rather than Generate because a stray Enter on Generate would replace the
board with no way back. Left alone because it changes desktop keyboard behavior
too — say the word if you want it.

37 tests, root lint and the production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)